### PR TITLE
Add for-await support for streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ const users = await sql`
 
 ```
 
-## Stream ```sql` `.stream(fn) -> Promise```
+## Streams
+
+### ```sql` `.stream(fn) -> Promise```
 
 If you want to handle rows returned by a query one by one you can use `.stream` which returns a promise that resolves once there are no more rows.
 ```js
@@ -116,6 +118,21 @@ await sql`
 `.stream(row => {
   // row = { created_at: '2019-11-22T14:22:00Z', name: 'connected' }
 })
+
+// No more rows
+
+```
+
+### With `for-await`
+
+If you are using a recent version of Node.JS (> v10), can use the new `for-await` to consume streams properly.
+```js
+
+for await (const row of await sql`
+  select created_at, name from events
+`) {
+  // row = { created_at: '2019-11-22T14:22:00Z', name: 'connected' }
+}
 
 // No more rows
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -169,6 +169,25 @@ function Postgres(url, options) {
     })
 
     promise.stream = (fn) => (query.stream = fn, promise)
+    
+    if (Symbol.asyncIterator)
+      promise[Symbol.asyncIterator] = () => {
+        let locked = [], resolved = [];
+        query.stream = row => locked.length ? locked.pop()({ done: false, value: row }) : resolved.push(Promise.resolve({ done: false, value: row }));
+        promise.then(() => locked.length ? locked.pop()({ done: true }) : resolved.push(Promise.resolve({ done: true })))
+        return {
+          return() {
+            // TODO Abort the query properly
+            return Promise.resolve({ done: true });
+          },
+          next() {
+            return resolved.length ? resolved.pop() : new Promise(res => locked.push(res)); 
+          },
+          throw() {
+            return Promise.resolve({ done: true });
+          }
+        }
+      };
 
     return promise
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -765,6 +765,30 @@ t('Stream works', async() => {
   return [1, result]
 })
 
+t('Stream works with for-await', async() => {
+  let result
+  for await (const { x } of sql`select 1 as x`)
+    result = x
+  return [1, result]
+})
+
+t('Stream works with for-await with big results', async() => {
+  let result = 0
+  for await (const { generate_series: x } of sql`select * from generate_series(1, 100000)`)
+    result += x;
+  return [4699408878, result]
+})
+
+t('Stream works with for-await with interruption', async() => {
+  let result = 0
+  for await (const { generate_series: x } of sql`select * from generate_series(1, 100000)`) {
+    result += x;
+    if (result > 10000)
+      break;
+  }
+  return [10450, result]
+})
+
 t('Stream returns empty array', async() => {
   return [0, (await sql`select 1 as x`.stream(x => {})).length]
 })


### PR DESCRIPTION
Fix #1

This PR is a very simple and naive implementation of `for-await` for consuming stream. I added tests and updated the README.

Feel free to update or close if you have a better idea.

Otherwise, awesome project, thank you :smile: 

```js
let result = 0
for await (const { generate_series: x } of sql`select * from generate_series(1, 100000)`)
  result += x;
return [4699408878, result]
```