### PR TITLE
Fix hanging issue with sql.end

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -91,7 +91,7 @@ function Connection(options = {}) {
       ended = () => resolve(socket.end())
     })
 
-    process.nextTick(() => ready && ended())
+    process.nextTick(() => (ready || !backend.query) && ended())
 
     return promise
   }


### PR DESCRIPTION
When closing a connection, check if either `ready` is true or there's no running query
Fixes #32