### PR TITLE
Update license to the Unlicense

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,24 @@
-DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-                    Version 2, December 2004
+This is free and unencumbered software released into the public domain.
 
- Copyright (C) 2019 Rasmus Porsager <rasmus@porsager.com>
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
 
- Everyone is permitted to copy and distribute verbatim or modified
- copies of this license document, and changing it is allowed as long
- as the name is changed.
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
 
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 
-  0. You just DO WHAT THE FUCK YOU WANT TO.
+For more information, please refer to <http://unlicense.org/>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "/lib"
   ],
   "author": "Rasmus Porsager <rasmus@porsager.com>",
-  "license": "WTFPL",
+  "license": "Unlicense",
   "repository": "porsager/postgres",
   "keywords": [
     "driver",


### PR DESCRIPTION
As discussed in https://github.com/porsager/postgres/issues/78, this PR changes the repo's license to the [Unlicense](https://unlicense.org/), which is a public domain license with a "more legal" fallback way of saying "do what you want" than the one offered by WTFPL.