### PR TITLE
add support for named parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,20 @@ If you know what you're doing, you can use `unsafe` to pass any string you'd lik
 sql.unsafe('select ' + danger + ' from users where id = ' + dragons)
 
 ```
+
+Indexed parameters will be escaped by postgres.
+```js
+
+sql.unsafe('select ' + danger + ' from users where id = $1', [dragons])
+
+```
+
+Named parameters may contain letters, numbers, and underscores, however they must start with a letter.  Named parameters get converted to indexed parameters, which will be escaped by postgres.
+```js
+// $var_1 is valid, but $1_var is invalid
+sql.unsafe('select ' + danger + ' from users where id = $id', {id: dragons})
+```
+
 </details>
 
 ## Errors

--- a/README.md
+++ b/README.md
@@ -540,21 +540,32 @@ If you know what you're doing, you can use `unsafe` to pass any string you'd lik
 
 ```js
 
-sql.unsafe('select ' + danger + ' from users where id = ' + dragons)
+await sql.unsafe('select ' + danger + ' from users where id = ' + dragons)
 
 ```
 
 Indexed parameters will be escaped by postgres.
 ```js
 
-sql.unsafe('select ' + danger + ' from users where id = $1', [dragons])
+await sql.unsafe('select ' + danger + ' from users where id = $1', [dragons])
 
 ```
 
-Named parameters may contain letters, numbers, and underscores, however they must start with a letter.  Named parameters get converted to indexed parameters, which will be escaped by postgres.
+Named parameters may contain letters, numbers, and underscores, however they must start with a letter.  Named parameters get converted to indexed parameters, which will be escaped by postgres.  If the parameters object does not contain all expected keys, null values will be used.
 ```js
 // $var_1 is valid, but $1_var is invalid
-sql.unsafe('select ' + danger + ' from users where id = $id', {id: dragons})
+await sql.unsafe('select ' + danger + ' from users where id = $id', {id: dragons})
+```
+
+You may also call `sql.paramify(query, [args], strict = false)` directly if you want to enforce strict parameter naming.  With `strict` enabled, `postgres` will throw an error if the object does not contain all the expected keys.  This can help prevent naming errors.
+```js
+let params = sql.paramify('select ' + danger + ' from users where id = $id', {no: dragons}, true)
+// Error: Missing Parameters: id
+```
+
+```js
+let params = sql.paramify('select ' + danger + ' from users where id = $id', {id: dragons}, true)
+await sql.unsafe(...params)
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -568,6 +568,14 @@ let params = sql.paramify('select ' + danger + ' from users where id = $id', {id
 await sql.unsafe(...params)
 ```
 
+```js
+let params = sql.paramify('update users set first_name = $fname where id = $id', {id: 5}, false)
+await sql.unsafe(...params)
+// This will updated the first_name to `null`
+// This is the default behavior for sql.unsafe when using named parameters.
+await sql.unsafe('update users set first_name = $fname where id = $id', {id: 5})
+```
+
 </details>
 
 ## Errors

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const Url = require('url')
 const Connection = require('./connection.js')
 const Queue = require('./queue.js')
+const Paramify = require('./paramify.js')
 const { errors, PostgresError } = require('./errors.js')
 const {
   mergeUserTypes,
@@ -282,6 +283,11 @@ function Postgres(a, b) {
     }
 
     function unsafe(xs, args) {
+      if(typeof args === 'object' && !Array.isArray(args)){
+        let {text, values} = Paramify(xs,args)
+        xs = text
+        args = values
+      }
       return query({ raw: true, simple: !args, dynamic: true }, connection || getConnection(), xs, args || [])
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -273,6 +273,7 @@ function Postgres(a, b) {
       types: {},
       notify,
       unsafe,
+      paramify,
       array,
       file,
       json
@@ -282,9 +283,19 @@ function Postgres(a, b) {
       return sql`select pg_notify(${ channel }, ${ '' + payload })`
     }
 
+    function paramify(sql, args, strict = false) {
+      let result
+      if (strict){
+        result = Paramify.strict(sql,args)
+      } else {
+        result = Paramify.sparse(sql,args)
+      }
+      return [result.text, result.values]
+    }
+
     function unsafe(xs, args) {
       if(typeof args === 'object' && !Array.isArray(args)){
-        let {text, values} = Paramify(xs,args)
+        let {text, values} = Paramify.sparse(xs,args)
         xs = text
         args = values
       }

--- a/lib/paramify.js
+++ b/lib/paramify.js
@@ -2,7 +2,19 @@
 // the remaining characters may be any combination of letters/numbers/underscore
 var paramPattern = /\$[a-z][a-z0-9_]*\b/ig;
 
-function Paramify(sql, parameters) {
+function sparse(sql, parameters = {}) {
+  // match tokens into an array, remove leading $, filter to remove duplicates
+  let sqlParams = sql.match(paramPattern).map(t => t.substring(1)).filter((val, ix, arr) => arr.indexOf(val) === ix)
+  let text = sqlParams.reduce((reducedSqlQuery, param, ix) => {
+    let paramPattern = new RegExp('\\$' + param + '\\b', 'g')
+    return reducedSqlQuery.replace(paramPattern,'$' + (ix+1)) // pg params are 1-indexed
+  }, sql)
+  let values = sqlParams.map(p => parameters[p])
+
+  return {text, values}
+}
+
+function strict(sql, parameters) {
   let bindings = Object.keys(parameters);
   let sqlParams = sql
   .match(paramPattern) // get array of $tokens
@@ -31,4 +43,5 @@ function Paramify(sql, parameters) {
   return out;
 }
 
+var Paramify = {sparse, strict}
 module.exports = Paramify

--- a/lib/paramify.js
+++ b/lib/paramify.js
@@ -1,0 +1,34 @@
+// the first character of named parameter must be a letter
+// the remaining characters may be any combination of letters/numbers/underscore
+var paramPattern = /\$[a-z][a-z0-9_]*\b/ig;
+
+function Paramify(sql, parameters) {
+  let bindings = Object.keys(parameters);
+  let sqlParams = sql
+  .match(paramPattern) // get array of $tokens
+  .map(t => t.substring(1)) // remove '$' from $tokens in array
+  .filter((val, ix, arr) => arr.indexOf(val) === ix) // no duplicates
+
+  let useParams = bindings.filter(t => sqlParams.indexOf(t) !== -1).sort()
+  let useValues = useParams.map(t => parameters[t])
+
+  let unmatched = sqlParams.filter(t => bindings.indexOf(t) === -1)
+  if (unmatched.length) {
+    let missing = unmatched.join(", ");
+    throw new Error("Missing Parameters: " + missing);
+  }
+
+  let interpolatedSql = useParams.reduce(
+  function (reducedSqlQuery, param, ix) {
+    let paramPattern = new RegExp('\\$' + param + '\\b', 'g');
+    return reducedSqlQuery.replace(paramPattern,'$' + (ix+1)); // pg params are 1-indexed
+  }, sql);
+
+  let out = {};
+  out.text = interpolatedSql;
+  out.values = useValues;
+
+  return out;
+}
+
+module.exports = Paramify

--- a/tests/index.js
+++ b/tests/index.js
@@ -503,6 +503,17 @@ t('unsafe simple', async() => {
   return [1, (await sql.unsafe('select 1 as x'))[0].x]
 })
 
+t('unsafe named params', async() => {
+  await sql`create table test (x int)`
+  return [1, (await sql.unsafe('insert into test values ($val) returning *', {val: 1}))[0].x]
+}, () => sql`drop table test`)
+
+t('unsafe paramify strict', async() => {
+  await sql`create table test (x int)`
+  let params = sql.parmify('insert into test values ($val) returning *', {val: 1}, true)
+  return [1, (await sql.unsafe(...params))[0].x]
+}, () => sql`drop table test`)
+
 t('listen and notify', async() => {
   const sql = postgres(options)
       , channel = 'hello'


### PR DESCRIPTION
To further reduce mistakes in "unsafe" queries, I've added support for named variables.
The `paramify` function parses the query and replaces named params with indexed params.

```js
let dynamically_built_sql = 'select * from users where id = $id'
let bindings = {id: 5}
await sql.unsafe(dynamically_built_sql, bindings)
// converts & runs query as: 'select * from users where id = $1'
```