### PR TITLE
import/export syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,21 @@
 <br>
 
 **Install**
-```bash
+```sh
 $ npm install postgres
 ```
 
 **Use**
 ```js
 // db.js
-const postgres = require('postgres')
+import postgres from 'postgres'
 
-const sql = postgres({ ...options }) // will default to the same as psql
-
-module.exports = sql
+export const sql = postgres({ ...options }) // will default to the same as psql
 ```
 
 ```js
 // other.js
-const sql = require('./db.js')
+import sql from './db.js'
 
 await sql`
   select name, age from users


### PR DESCRIPTION
Node.js now allows import/export syntax.
Also you use top-level await, so i assume this change is welcome

Also in readme, import/export syntax is used in [asas](https://github.com/porsager/postgres/blob/master/README.md#sample-shutdown-using-prexit)