### PR TITLE
Expose the PostgresError type for TypeScript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -93,7 +93,10 @@ type UnwrapPromiseArray<T> = T extends any[] ? {
   [k in keyof T]: T[k] extends Promise<infer R> ? R : T[k]
 } : T;
 
+type PostgresErrorType = PostgresError
+
 declare namespace postgres {
+  type PostgresError = PostgresErrorType
 
   /**
    * Convert a string to Pascal case.


### PR DESCRIPTION
With current `index.d.ts` it seems to be impossible to get hold of the `PostgresError` type. It would be useful for e.g. signatures of error handling functions.

Fix by exposing the type but not the class.