### PR TITLE
[WIP] Support running Postgres in Docker for tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,18 @@
+name: Docker
+
+on: workflow_dispatch
+
+jobs:
+   build-container:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: echo $GITHUB_TOKEN | docker login https://docker.pkg.github.com -u akheron --password-stdin
+
+      - working-directory: ci
+        run: docker build -t docker.pkg.github.com/akheron/postres/postgres-for-test:latest .
+
+      - working-directory: ci
+        run: docker push docker.pkg.github.com/akheron/postres/postgres-for-test:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test
+
+on: push
+
+#  push:
+#    branches: [ master ]
+#  pull_request:
+#    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 15.x]
+    
+    services:
+      postgres:
+        image: docker.pkg.github.com/akheron/packages-test/postgres-for-test:latest
+        credentials:
+          username: akheron
+          password: ${{github.token}}
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports: 
+          - "5432:5432"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Run tests
+      env:
+        PGHOST: localhost
+        PGUSER: postgres
+      run: npm test    

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,4 @@
+FROM postgres:latest
+
+RUN mkdir /socket && chmod 0777 /socket
+COPY setup.sh setup.sql /docker-entrypoint-initdb.d/

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+cd /var/lib/postgresql/data
+
+openssl req \
+    -new -x509 -days 365 -nodes -text \
+    -out server.crt -keyout server.key -subj "/CN=localhost"
+chmod og-rwx server.key
+
+sed -ri \
+    -e "s/^#ssl = .*/ssl = on/" \
+    -e "s/^#password_encryption = .*/password_encryption = scram-sha-256/" \
+    -e "s/^#unix_socket_directories = .*/unix_socket_directories = '\\/socket'/" \
+    -e "s/^#unix_socket_permissions = .*/unix_socket_permissions = 0777/" \
+    postgresql.conf
+
+cat > pg_hba.conf <<EOF
+# Trust all unix domain socket connections.
+local  all                all                                  trust
+
+# Allow test users to connect to the postgres_js_test database
+# with the expected authentication method
+host   postgres_js_test   postgres_js_test           all       trust
+host   postgres_js_test   postgres_js_test_clear     all       password
+host   postgres_js_test   postgres_js_test_md5       all       md5
+host   postgres_js_test   postgres_js_test_scram     all       scram-sha-256
+
+# Allow user "postgres" to connect to database "postgres"
+# (for the "Connects with no options" test)
+host   postgres           postgres             all       trust
+EOF
+
+# Reload config before running setup.sql
+pg_ctl reload

--- a/ci/setup.sql
+++ b/ci/setup.sql
@@ -1,0 +1,4 @@
+create user postgres_js_test password null;
+create user postgres_js_test_clear password 'postgres_js_test_clear';
+create user postgres_js_test_md5 password 'postgres_js_test_md5';
+create user postgres_js_test_scram password 'postgres_js_test_scram';

--- a/tests/index.js
+++ b/tests/index.js
@@ -881,7 +881,7 @@ t('Transform value', async() => {
 t('Unix socket', async() => {
   const sql = postgres({
     ...options,
-    host: '/tmp'
+    host: process.env.PGSOCKET || '/tmp'
   })
 
   return [1, (await sql`select 1 as x`)[0].x]


### PR DESCRIPTION
Here's a Dockerfile for running tests against a Postgres that's run in Docker.

To make all tests pass, the Postgres' unix domain socket must be made available in the host via a bind mount volume.

Run postgres:
```sh
cd ci
docker build -t postgres-test .
mkdir socket
chmod 777 socket
docker run --rm -e POSTGRES_PASSWORD=dummy -p 5432:5432 -v $(pwd)/socket:/socket postgres-test:latest
```

Run tests:
```
PGHOST=localhost PGUSER=postgres PGSOCKET=ci/socket npm run test
```

I can try to add a full CI setup if there's interest.