### PR TITLE
Include custom types when fetching array types.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -243,7 +243,7 @@ function Postgres(a, b) {
           select b.oid, b.typarray
           from pg_catalog.pg_type a
           left join pg_catalog.pg_type b on b.oid = a.typelem
-          where a.typcategory = 'A' and b.typcategory != 'C'
+          where a.typcategory = 'A'
           group by b.oid, b.typarray
           order by b.oid
         `)


### PR DESCRIPTION
Removes a 'where' condition in the query used when fetching the arrays types in the database

All tests pass with Node version 14.7.0 and Postgresql 12.3

Fixes issue #94