### PR TITLE
Fix typo, assign result to variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ module.exports = sql
 // other.js
 const sql = require('./db.js')
 
-await sql`
+const users = await sql`
   select name, age from users
 `
-// > [{ name: 'Murray', age: 68 }, { name: 'Walter', age 78 }]
+// users: [{ name: 'Murray', age: 68 }, { name: 'Walter', age: 78 }]
 ```
 
 ## Connection options `postgres([url], [options])`


### PR DESCRIPTION
Hey @porsager, hope you are well!

Quick PR to fix the missing `:` and assign the result of the query to a variable.