### PR TITLE
int8 can be represented as number in js

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -10,7 +10,7 @@ const types = module.exports.types = {
   },
   number: {
     to: 0,
-    from: [21, 23, 26, 700, 701],
+    from: [20, 21, 23, 26, 700, 701],
     serialize: x => '' + x,
     parse: x => +x
   },


### PR DESCRIPTION
The `COUNT(*)` aggregate function in postgres returns a bigint. I think this should be treated as a numeric in javascript.

See this for comments: https://github.com/koestler/postgres/commit/544a7385ff7c9688f7b148b76ed76a23e604431e

However, if a remember correctly, js uses a float64 for all numerics. So not int8 values will have an exact representation.
