### PR TITLE
Fix undefined socket if stop postgresql.service at beginning.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -259,10 +259,12 @@ function postgresSocket(options, {
   let buffer
 
   function onclose() {
-    socket.removeListener('data', data)
-    socket.removeListener('error', error)
-    socket.removeListener('connect', ready)
-    socket.removeListener('secureConnect', ready)
+    if (socket) {
+      socket.removeListener('data', data)
+      socket.removeListener('error', error)
+      socket.removeListener('connect', ready)
+      socket.removeListener('secureConnect', ready)
+    }
     closed = true
     close()
   }


### PR DESCRIPTION
1. sudo systemctl stop postgresql.service

2. start program

3. got TypeError: Cannot read property removeListener of undefined at Socket.onclose

Tested on: 
Arch Linux 5.9.13-arch1-1
PostgreSQL 13
postgres 1.0.2 and 2.0.0-beta.2

Btw:
If I start program and then stop postgresql.service, all are OK.
I don't know why got undefined socket if stop postgresql.service at beginning.
I guess nodejs net.connect removes socket.

