### PR TITLE
Fix SCRAM-SHA-256 authentication by cloning the options object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -218,7 +218,9 @@ function Postgres(a, b) {
 
   function createConnection(options) {
     slots--
-    const connection = Connection(options)
+    // The options object gets cloned as the as the authentication in the frontend.js mutates the
+    // options to persist a nonce and signature, which are unique per connection.
+    const connection = Connection({...options})
     all.push(connection)
     return connection
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -317,6 +317,15 @@ t('Login using scram-sha-256', async() => {
   return [true, (await postgres({ ...options, ...login_scram })`select true as x`)[0].x]
 })
 
+t('Parallel connections using scram-sha-256', async() => {
+  const sql = postgres({ ...options, ...login_scram })
+  return [true, (await Promise.all([
+    sql`select true as x, pg_sleep(0.2)`,
+    sql`select true as x, pg_sleep(0.2)`,
+    sql`select true as x, pg_sleep(0.2)`
+  ]))[0][0].x]
+})
+
 t('Support dynamic password function', async() => {
   return [true, (await postgres({
     ...options,


### PR DESCRIPTION
This pull request fixes the issue for SCRAM authentication mentioned in #123.
The options object is mutated at two places during the authentication to persist connection information. 
To set a `nonce`: https://github.com/porsager/postgres/blob/4d5fdc108a5dac18145c748d13da2fe0d8c02b22/lib/frontend.js#L97
And to set the `serverSignature`: https://github.com/porsager/postgres/blob/4d5fdc108a5dac18145c748d13da2fe0d8c02b22/lib/frontend.js#L122

By cloning the object, we can safely mutate it to successfully do the handshake.