### PR TITLE
feat: implements unlisten functionality

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -341,15 +341,18 @@ function Postgres(a, b) {
 
     if (channel in listeners) {
       listeners[channel].push(fn)
-      return Promise.resolve(listener.result)
+      return Promise.resolve(Object.assign({}, listener.result, {
+        unlisten,
+      }))
     }
 
     listeners[channel] = [fn]
     return query({ raw: true }, listener.conn, 'listen ' + escape(channel))
-      .then((response) => {
-        response.unlisten = unlisten
-        listener.result = response
-        return response
+      .then((result) => {
+        listener.result = result
+        return Object.assign({}, listener.result, {
+          unlisten,
+        })
       })
 
     function unlisten() {
@@ -361,7 +364,7 @@ function Postgres(a, b) {
 
       if (!listeners[channel].length) {
         delete listeners[channel]
-        return query({ raw: true }, getListener(), 'unlisten ' + escape(channel))
+        return query({ raw: true }, getListener().conn, 'unlisten ' + escape(channel))
           .then(() => {})
       }
       return Promise.resolve()

--- a/lib/index.js
+++ b/lib/index.js
@@ -344,6 +344,21 @@ function Postgres(a, b) {
 
     listeners[channel] = [fn]
     return query({ raw: true }, getListener(), 'listen ' + escape(channel))
+      .then((result) => {
+        result.unlisten = unlisten
+        return result
+      })
+
+    function unlisten() {
+      const index = listeners[channel].indexOf(fn)
+      if (index !== -1)
+        listeners[channel].splice(index, 1)
+      if (!listeners[channel].length) {
+        delete listeners[channel]
+        return query({ raw: true }, getListener(), 'unlisten ' + escape(channel))
+      }
+      return Promise.resolve()
+    }
   }
 
   function getListener() {
@@ -351,7 +366,7 @@ function Postgres(a, b) {
       return listener
 
     listener = Connection(Object.assign({
-      onnotify: (c, x) => c in listeners && listeners[c].forEach(fn => fn(x)),
+      onnotify: (c, x) => c in listeners && listeners[c].slice(0).forEach(fn => fn(x)),
       onclose: () => {
         Object.entries(listeners).forEach(([channel, fns]) => {
           delete listeners[channel]

--- a/lib/index.js
+++ b/lib/index.js
@@ -353,12 +353,16 @@ function Postgres(a, b) {
       })
 
     function unlisten() {
-      const index = listeners[channel].indexOf(fn)
-      if (index !== -1)
-        listeners[channel].splice(index, 1)
+      if (!listeners[channel]) {
+        return Promise.resolve()
+      }
+
+      listeners[channel] = listeners[channel].filter(handler => handler !== fn)
+
       if (!listeners[channel].length) {
         delete listeners[channel]
         return query({ raw: true }, getListener(), 'unlisten ' + escape(channel))
+          .then(() => {})
       }
       return Promise.resolve()
     }
@@ -369,7 +373,7 @@ function Postgres(a, b) {
       return listener
 
     const conn = Connection(Object.assign({
-      onnotify: (c, x) => c in listeners && listeners[c].slice(0).forEach(fn => fn(x)),
+      onnotify: (c, x) => c in listeners && listeners[c].forEach(fn => fn(x)),
       onclose: () => {
         Object.entries(listeners).forEach(([channel, fns]) => {
           delete listeners[channel]

--- a/lib/index.js
+++ b/lib/index.js
@@ -337,16 +337,19 @@ function Postgres(a, b) {
   }
 
   function listen(channel, fn) {
+    const listener = getListener();
+
     if (channel in listeners) {
       listeners[channel].push(fn)
-      return Promise.resolve(channel)
+      return Promise.resolve(listener.result)
     }
 
     listeners[channel] = [fn]
-    return query({ raw: true }, getListener(), 'listen ' + escape(channel))
-      .then((result) => {
-        result.unlisten = unlisten
-        return result
+    return query({ raw: true }, listener.conn, 'listen ' + escape(channel))
+      .then((response) => {
+        response.unlisten = unlisten
+        listener.result = response
+        return response
       })
 
     function unlisten() {
@@ -365,18 +368,20 @@ function Postgres(a, b) {
     if (listener)
       return listener
 
-    listener = Connection(Object.assign({
+    const conn = Connection(Object.assign({
       onnotify: (c, x) => c in listeners && listeners[c].slice(0).forEach(fn => fn(x)),
       onclose: () => {
         Object.entries(listeners).forEach(([channel, fns]) => {
           delete listeners[channel]
           Promise.all(fns.map(fn => listen(channel, fn).catch(() => { /* noop */ })))
         })
+        listener = null;
       }
     },
       options
     ))
-    all.push(listener)
+    listener = { conn, result: null };
+    all.push(conn);
     return listener
   }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -613,6 +613,22 @@ t('listen after unlisten', async() => {
   return ['ac', xs.join('')]
 })
 
+t('multiple listeners and unlisten one', async() => {
+  const listener = postgres(options)
+      , xs = []
+
+  await listener.listen('test', x => xs.push(x))
+  const s2 = await listener.listen('test', x => xs.push(x))
+  await listener.notify('test', 'a')
+  await delay(50)
+  await s2.unlisten()
+  await listener.notify('test', 'b')
+  await delay(50)
+  listener.end();
+
+  return ['aab', xs.join('')]
+})
+
 t('responds with server parameters (application_name)', async() =>
   ['postgres.js', await new Promise((resolve, reject) => postgres({
     ...options,

--- a/tests/index.js
+++ b/tests/index.js
@@ -580,6 +580,39 @@ t('listen reconnects', async() => {
   return ['ab', xs.join('')]
 })
 
+t('unlisten removes subscription', async() => {
+  const listener = postgres(options)
+      , xs = []
+
+  const { unlisten } = await listener.listen('test', x => xs.push(x))
+  await listener.notify('test', 'a')
+  await delay(50)
+  await unlisten()
+  await listener.notify('test', 'b')
+  await delay(50)
+  listener.end()
+
+  return ['a', xs.join('')]
+})
+
+t('listen after unlisten', async() => {
+  const listener = postgres(options)
+      , xs = []
+
+  const { unlisten } = await listener.listen('test', x => xs.push(x))
+  await listener.notify('test', 'a')
+  await delay(50)
+  await unlisten()
+  await listener.notify('test', 'b')
+  await delay(50)
+  await listener.listen('test', x => xs.push(x))
+  await listener.notify('test', 'c')
+  await delay(50)
+  listener.end();
+
+  return ['ac', xs.join('')]
+})
+
 t('responds with server parameters (application_name)', async() =>
   ['postgres.js', await new Promise((resolve, reject) => postgres({
     ...options,

--- a/tests/index.js
+++ b/tests/index.js
@@ -617,8 +617,8 @@ t('multiple listeners and unlisten one', async() => {
   const listener = postgres(options)
       , xs = []
 
-  await listener.listen('test', x => xs.push(x))
-  const s2 = await listener.listen('test', x => xs.push(x))
+  await listener.listen('test', x => xs.push('1', x))
+  const s2 = await listener.listen('test', x => xs.push('2', x))
   await listener.notify('test', 'a')
   await delay(50)
   await s2.unlisten()
@@ -626,7 +626,7 @@ t('multiple listeners and unlisten one', async() => {
   await delay(50)
   listener.end();
 
-  return ['aab', xs.join('')]
+  return ['1a2a1b', xs.join('')]
 })
 
 t('responds with server parameters (application_name)', async() =>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -295,8 +295,8 @@ declare namespace postgres {
 
   interface PendingRequest extends Promise<[] & ResultMeta<null>> { }
 
-  interface ListenRequest extends Promise<[] & ListenMeta> { }
-  interface ListenMeta extends ResultMeta<null>{
+  interface ListenRequest extends Promise<ListenMeta> { }
+  interface ListenMeta extends ResultMeta<null> {
     unlisten(): Promise<void>
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -295,6 +295,11 @@ declare namespace postgres {
 
   interface PendingRequest extends Promise<[] & ResultMeta<null>> { }
 
+  interface ListenRequest extends Promise<[] & ListenMeta> { }
+  interface ListenMeta extends ResultMeta<null>{
+    unlisten(): Promise<void>
+  }
+
   interface Helper<T, U extends any[] = T[]> {
     first: T;
     rest: U;
@@ -336,7 +341,7 @@ declare namespace postgres {
     file<T extends any[] = Row[]>(path: string, options?: { cache?: boolean }): PendingQuery<AsRowList<T>>;
     file<T extends any[] = Row[]>(path: string, args: SerializableParameter[], options?: { cache?: boolean }): PendingQuery<AsRowList<T>>;
     json(value: any): Parameter;
-    listen(channel: string, cb: (value?: string) => void): PendingRequest;
+    listen(channel: string, cb: (value?: string) => void): ListenRequest;
     notify(channel: string, payload: string): PendingRequest;
     options: ParsedOptions<TTypes>;
     parameters: ConnectionParameters;


### PR DESCRIPTION
Relates to #133

BREAKING CHANGE: `listen` function returns an object instead of an empty array. All properties are preserved.