### PR TITLE
Multihost support for High Availability setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ You can use either a `postgres://` url connection string or the options to defin
 
 ```js
 const sql = postgres('postgres://username:password@host:port/database', {
-  host            : '',         // Postgres ip address or domain name
-  port            : 5432,       // Postgres server port
+  host            : '',         // Postgres ip address[s] or domain name[s]
+  port            : 5432,       // Postgres server port[s]
   path            : '',         // unix socket path (usually '/tmp')
   database        : '',         // Name of database to connect to
   username        : '',         // Username of database user
@@ -68,9 +68,14 @@ const sql = postgres('postgres://username:password@host:port/database', {
   connection      : {
     application_name  : 'postgres.js', // Default application_name
     ...                                // Other connection parameters
-  }
+  },
+  target_session_attrs : null   // Use 'read-write' with multiple hosts to 
+                                // ensure only connecting to primary
 })
 ```
+
+### SSL
+More info for the `ssl` option can be found in the [Node.js docs for tls connect options](https://nodejs.org/dist/latest-v10.x/docs/api/tls.html#tls_new_tls_tlssocket_socket_options).
 
 Although it is [vulnerable to MITM attacks](https://security.stackexchange.com/a/229297/174913), a common configuration for the `ssl` option for some cloud providers like Heroku is to set `rejectUnauthorized` to `false` (if `NODE_ENV` is `production`):
 
@@ -83,23 +88,31 @@ const sql =
     : postgres();
 ```
 
-More info for the `ssl` option can be found in the [Node.js docs for tls connect options](https://nodejs.org/dist/latest-v10.x/docs/api/tls.html#tls_new_tls_tlssocket_socket_options).
+### Multi host connections - High Availability (HA)
+
+Connection uri strings with multiple hosts works like in [`psql multiple host uris`](https://www.postgresql.org/docs/13/libpq-connect.html#LIBPQ-MULTIPLE-HOSTS)
+
+Connecting to the specified hosts/ports will be tried in order, and on a successfull connection retries will be reset. This ensures that hosts can come up and down seamless to your application.
+
+If you specify `target_session_attrs: 'read-write'` or `PGTARGETSESSIONATTRS=read-write` Postgres.js will only connect to a writeable host allowing for zero down time failovers.
 
 ### Environment Variables for Options
 
-It is also possible to connect to the database without a connection string or options, which will read the options from the environment variables in the table below:
+It is also possible to connect to the database without a connection string or any options. Postgres.js will fall back to the common environment variables used by `psql` as in the table below:
 
 ```js
 const sql = postgres()
 ```
 
-| Option     | Environment Variables    |
-| ---------- | ------------------------ |
-| `host`     | `PGHOST`                 |
-| `port`     | `PGPORT`                 |
-| `database` | `PGDATABASE`             |
-| `username` | `PGUSERNAME` or `PGUSER` |
-| `password` | `PGPASSWORD`             |
+| Option            | Environment Variables    |
+| ----------------- | ------------------------ |
+| `host`            | `PGHOST`                 |
+| `port`            | `PGPORT`                 |
+| `database`        | `PGDATABASE`             |
+| `username`        | `PGUSERNAME` or `PGUSER` |
+| `password`        | `PGPASSWORD`             |
+| `idle_timeout`    | `PGIDLE_TIMEOUT`         |
+' `connect_timeout` | `PGCONNECT_TIMEOUT`      |
 
 ## Query ```sql` ` -> Promise```
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -29,6 +29,8 @@ function Connection(options = {}) {
   let ended
   let open = false
   let ready = false
+  let write = false
+  let next = false
   let statements = {}
   let connect_timer
 
@@ -41,7 +43,8 @@ function Connection(options = {}) {
     ready,
     data,
     error,
-    close
+    close,
+    cleanup
   })
 
   const backend = Backend({
@@ -210,6 +213,9 @@ function Connection(options = {}) {
     idle()
 
     if (!open) {
+      if (multi())
+        return
+
       messages.forEach(socket.write)
       messages = []
       open = true
@@ -218,6 +224,24 @@ function Connection(options = {}) {
     backend.query = queries.shift()
     ready = !backend.query
     ready && ended && ended()
+  }
+
+  function multi() {
+    if (next)
+      return (next = false, true)
+
+    if (!write && options.target_session_attrs === 'read-write') {
+      backend.query = {
+        result: [],
+        statement: {},
+        resolve: ([{ transaction_read_only }]) => transaction_read_only === 'on'
+          ? (next = true, socket.destroy())
+          : (write = true, socket.success()),
+        reject: error
+      }
+      socket.write(frontend.Query('show transaction_read_only'))
+      return true
+    }
   }
 
   function data(x) {
@@ -238,10 +262,13 @@ function Connection(options = {}) {
   function close() {
     clearTimeout(connect_timer)
     error(errors.connection('CONNECTION_CLOSED', options))
-    statements = {}
     messages = []
-    open = ready = false
     onclose && onclose()
+  }
+
+  function cleanup() {
+    statements = {}
+    open = ready = write = false
   }
 
   /* c8 ignore next */
@@ -251,8 +278,11 @@ function Connection(options = {}) {
 function postgresSocket(options, {
   error,
   close,
+  cleanup,
   data
 }) {
+  const multi = Array.isArray(options.host)
+
   let socket
   let closed = true
   let next = null
@@ -260,22 +290,22 @@ function postgresSocket(options, {
   let i = 0
 
   function onclose(err) {
-    cleanup()
-
-    Array.isArray(options.host) && ++i < options.host.length
+    oncleanup()
+    multi && i < options.host.length
       ? connect()
       : err instanceof Error
         ? error(err)
         : close()
   }
 
-  function cleanup() {
+  function oncleanup() {
     socket.removeListener('data', data)
     socket.removeListener('close', onclose)
     socket.removeListener('error', onclose)
     socket.removeListener('connect', ready)
     socket.removeListener('secureConnect', ready)
     closed = true
+    cleanup()
   }
 
   function connect() {
@@ -283,12 +313,11 @@ function postgresSocket(options, {
       return
 
     closed = false
-
     const socket = options.path
       ? net.connect(options.path)
       : net.connect(
-        Array.isArray(options.port) ? options.port[i] : options.port,
-        Array.isArray(options.host) ? options.host[i] : options.host
+        multi ? options.port[i] : options.port,
+        multi ? options.host[i++] : options.host
       )
 
     if (!options.ssl)
@@ -325,6 +354,9 @@ function postgresSocket(options, {
   }
 
   const x = {
+    success: () => {
+      multi && i >= options.host.length && (i = 0)
+    },
     write: x => {
       buffer = buffer ? Buffer.concat([buffer, x]) : Buffer.from(x)
       if (buffer.length >= 1024)

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -323,7 +323,7 @@ function postgresSocket(options, {
     if (!options.ssl)
       return attach(socket)
 
-    socket.once('connect', () => socket.write(frontend.sslRequest))
+    socket.once('connect', () => socket.write(frontend.SSLRequest))
     socket.once('error', onclose)
     socket.once('close', onclose)
     socket.once('data', x => {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -105,7 +105,7 @@ function Connection(options = {}) {
   }
 
   function destroy() {
-    error(errors.connection('CONNECTION_DESTROYED', options))
+    error(errors.connection('CONNECTION_DESTROYED', options, socket))
     socket.destroy()
   }
 
@@ -153,7 +153,7 @@ function Connection(options = {}) {
   }
 
   function connectTimedOut() {
-    error(errors.connection('CONNECT_TIMEOUT', options))
+    error(errors.connection('CONNECT_TIMEOUT', options, socket))
     socket.destroy()
   }
 
@@ -261,7 +261,7 @@ function Connection(options = {}) {
 
   function close() {
     clearTimeout(connect_timer)
-    error(errors.connection('CONNECTION_CLOSED', options))
+    error(errors.connection('CONNECTION_CLOSED', options, socket))
     messages = []
     onclose && onclose()
   }
@@ -281,8 +281,6 @@ function postgresSocket(options, {
   cleanup,
   data
 }) {
-  const multi = Array.isArray(options.host)
-
   let socket
   let closed = true
   let next = null
@@ -291,11 +289,12 @@ function postgresSocket(options, {
 
   function onclose(err) {
     oncleanup()
-    multi && i < options.host.length
+    i < options.host.length
       ? connect()
       : err instanceof Error
         ? error(err)
         : close()
+    i >= options.host.length && (i = 0)
   }
 
   function oncleanup() {
@@ -317,8 +316,8 @@ function postgresSocket(options, {
     socket = options.path
       ? net.connect(options.path)
       : net.connect(
-        multi ? options.port[i] : options.port,
-        multi ? options.host[i++] : options.host
+        x.port = options.port[i],
+        x.host = options.host[i++]
       )
 
     if (!options.ssl)
@@ -364,7 +363,7 @@ function postgresSocket(options, {
 
   const x = {
     success: () => {
-      multi && i >= options.host.length && (i = 0)
+      i >= options.host.length && (i = 0)
     },
     write: x => {
       buffer = buffer ? Buffer.concat([buffer, x]) : Buffer.from(x)

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -284,13 +284,14 @@ function postgresSocket(options, {
 }) {
   let socket
   let closed = true
+  let succeeded = false
   let next = null
   let buffer
   let i = 0
 
   function onclose(err) {
     oncleanup()
-    i < options.host.length
+    !succeeded && i < options.host.length
       ? connect()
       : err instanceof Error
         ? error(err)
@@ -312,7 +313,7 @@ function postgresSocket(options, {
     if (!closed)
       return
 
-    closed = false
+    closed = succeeded = false
 
     socket = options.path
       ? net.connect(options.path)
@@ -364,6 +365,7 @@ function postgresSocket(options, {
 
   const x = {
     success: () => {
+      succeeded = true
       i >= options.host.length && (i = 0)
     },
     write: x => {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -192,6 +192,7 @@ function Connection(options = {}) {
     clearTimeout(connect_timer)
     if (err) {
       if (backend.query) {
+        err.stack += backend.query.origin.replace(/.*\n/, '\n')
         Object.defineProperty(err, 'query', {
           value: backend.query.str,
           enumerable: !!options.debug

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -280,7 +280,7 @@ function postgresSocket(options, {
     if (!options.ssl)
       return attach(socket)
 
-    socket.once('connect', () => socket.write(Buffer.from('0000000804d2162f', 'hex')))
+    socket.once('connect', () => socket.write(frontend.sslRequest))
     socket.once('error', error)
     socket.once('close', onclose)
     socket.once('data', x => {
@@ -303,7 +303,7 @@ function postgresSocket(options, {
 
   function ready() {
     try {
-      socket.write(frontend.connect(options))
+      socket.write(frontend.StartupMessage(options))
     } catch (e) {
       error(e)
       socket.end()

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -257,14 +257,25 @@ function postgresSocket(options, {
   let closed = true
   let next = null
   let buffer
+  let i = 0
 
-  function onclose() {
+  function onclose(err) {
+    cleanup()
+
+    Array.isArray(options.host) && ++i < options.host.length
+      ? connect()
+      : err instanceof Error
+        ? error(err)
+        : close()
+  }
+
+  function cleanup() {
     socket.removeListener('data', data)
-    socket.removeListener('error', error)
+    socket.removeListener('close', onclose)
+    socket.removeListener('error', onclose)
     socket.removeListener('connect', ready)
     socket.removeListener('secureConnect', ready)
     closed = true
-    close()
   }
 
   function connect() {
@@ -275,16 +286,19 @@ function postgresSocket(options, {
 
     const socket = options.path
       ? net.connect(options.path)
-      : net.connect(options.port, options.host)
+      : net.connect(
+        Array.isArray(options.port) ? options.port[i] : options.port,
+        Array.isArray(options.host) ? options.host[i] : options.host
+      )
 
     if (!options.ssl)
       return attach(socket)
 
     socket.once('connect', () => socket.write(frontend.sslRequest))
-    socket.once('error', error)
+    socket.once('error', onclose)
     socket.once('close', onclose)
     socket.once('data', x => {
-      socket.removeListener('error', error)
+      socket.removeListener('error', onclose)
       socket.removeListener('close', onclose)
       x.toString() === 'S'
         ? attach(tls.connect(Object.assign({ socket }, options.ssl)))
@@ -295,7 +309,7 @@ function postgresSocket(options, {
   function attach(x) {
     socket = x
     socket.on('data', data)
-    socket.once('error', error)
+    socket.once('error', onclose)
     socket.once('connect', ready)
     socket.once('secureConnect', ready)
     socket.once('close', onclose)

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -192,7 +192,6 @@ function Connection(options = {}) {
     clearTimeout(connect_timer)
     if (err) {
       if (backend.query) {
-        err.stack += backend.query.origin.replace(/.*\n/, '\n')
         Object.defineProperty(err, 'query', {
           value: backend.query.str,
           enumerable: !!options.debug
@@ -232,6 +231,7 @@ function Connection(options = {}) {
 
     if (!write && options.target_session_attrs === 'read-write') {
       backend.query = {
+        origin: '',
         result: [],
         statement: {},
         resolve: ([{ transaction_read_only }]) => transaction_read_only === 'on'

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -15,14 +15,14 @@ module.exports.errors = {
   notSupported
 }
 
-function connection(x, options) {
+function connection(x, options, socket) {
   const error = Object.assign(
-    new Error(('write ' + x + ' ' + (options.path || (options.host + ':' + options.port)))),
+    new Error(('write ' + x + ' ' + (options.path || (socket.host + ':' + socket.port)))),
     {
       code: x,
       errno: x,
-      address: options.path || options.host
-    }, options.path ? {} : { port: options.port }
+      address: options.path || socket.host
+    }, options.path ? {} : { port: socket.port }
   )
   Error.captureStackTrace(error, connection)
   return error

--- a/lib/frontend.js
+++ b/lib/frontend.js
@@ -12,6 +12,8 @@ const execute = Buffer.concat([
   bytes.S().end()
 ])
 
+const SSLRequest = bytes.i32(8).i32(80877103).end(8)
+
 const authNames = {
   2 : 'KerberosV5',
   3 : 'CleartextPassword',
@@ -33,9 +35,9 @@ const auths = {
   12: SASLFinal
 }
 
-
 module.exports = {
-  connect,
+  StartupMessage,
+  SSLRequest,
   auth,
   Bind,
   Parse,
@@ -44,7 +46,7 @@ module.exports = {
   Execute
 }
 
-function connect({ user, database, connection }) {
+function StartupMessage({ user, database, connection }) {
   return bytes
     .inc(4)
     .i16(3)

--- a/lib/index.js
+++ b/lib/index.js
@@ -386,8 +386,8 @@ function Postgres(a, b) {
     },
       options
     ))
-    listener = { conn, result: {} };
-    all.push(conn);
+    listener = { conn, result: {} }
+    all.push(conn)
     return listener
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,7 @@ function Postgres(a, b) {
       query.resolve = resolve
       query.reject = reject
       ended !== null
-        ? reject(errors.connection('CONNECTION_ENDED', options))
+        ? reject(errors.connection('CONNECTION_ENDED', options, options))
         : ready
           ? send(connection, query, xs, args)
           : fetchArrayTypes(connection).then(() => send(connection, query, xs, args)).catch(reject)
@@ -536,15 +536,15 @@ function Postgres(a, b) {
 function parseOptions(a, b) {
   const env = process.env // eslint-disable-line
       , o = (typeof a === 'string' ? b : a) || {}
-      , { url, hosts, ports } = parseUrl(a, env)
+      , { url, multihost } = parseUrl(a, env)
       , auth = (url.auth || '').split(':')
-      , host = o.hostname || o.host || hosts || url.hostname || env.PGHOST || 'localhost'
-      , port = o.port || ports || url.port || env.PGPORT || 5432
+      , host = o.hostname || o.host || multihost || url.hostname || env.PGHOST || 'localhost'
+      , port = o.port || url.port || env.PGPORT || 5432
       , user = o.user || o.username || auth[0] || env.PGUSERNAME || env.PGUSER || osUsername()
 
   return Object.assign({
-    host,
-    port,
+    host            : host.split(',').map(x => x.split(':')[0]),
+    port            : host.split(',').map(x => x.split(':')[1] || port),
     path            : o.path || host.indexOf('/') > -1 && host + '/.s.PGSQL.' + port,
     database        : o.database || o.db || (url.pathname || '').slice(1) || env.PGDATABASE || user,
     user            : user,
@@ -566,21 +566,18 @@ function parseOptions(a, b) {
   )
 }
 
-function parseUrl(url, env) {
+function parseUrl(url) {
   if (typeof url !== 'string')
     return { url: { query: {} } }
 
-  let $ = url
-  $ = $.slice($.indexOf('://') + 3)
-  $ = $.split(/[?/]/)[0]
-  $ = $.slice($.indexOf('@') + 1)
-
-  const hosts = $.split(',')
+  let host = url
+  host = host.slice(host.indexOf('://') + 3)
+  host = host.split(/[?/]/)[0]
+  host = host.slice(host.indexOf('@') + 1)
 
   return {
-    url: Url.parse(url.replace($, hosts[0]), true),
-    hosts: hosts.length > 1 && hosts.map(x => x.split(':')[0]),
-    ports: hosts.length > 1 && hosts.map(x => x.split(':')[1] || env.PGPORT || 5432)
+    url: Url.parse(url.replace(host, host.split(',')[0]), true),
+    multihost: host.indexOf(',') > -1 && host
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -537,6 +537,7 @@ function parseOptions(a, b) {
     onparameter     : o.onparameter,
     transform       : Object.assign({}, o.transform),
     connection      : Object.assign({ application_name: 'postgres.js' }, o.connection),
+    target_session_attrs: o.target_session_attrs || env.PGTARGETSESSIONATTRS,
     debug           : o.debug
   },
     mergeUserTypes(o.types)

--- a/lib/index.js
+++ b/lib/index.js
@@ -513,11 +513,11 @@ function Postgres(a, b) {
 
 function parseOptions(a, b) {
   const env = process.env // eslint-disable-line
-      , url = typeof a === 'string' ? Url.parse(a, true) : { query: {}, pathname: '' }
       , o = (typeof a === 'string' ? b : a) || {}
+      , { url, hosts, ports } = parseUrl(a, env)
       , auth = (url.auth || '').split(':')
-      , host = o.hostname || o.host || url.hostname || env.PGHOST || 'localhost'
-      , port = o.port || url.port || env.PGPORT || 5432
+      , host = o.hostname || o.host || hosts || url.hostname || env.PGHOST || 'localhost'
+      , port = o.port || ports || url.port || env.PGPORT || 5432
 
   return Object.assign({
     host,
@@ -526,7 +526,7 @@ function parseOptions(a, b) {
     database        : o.database || o.db || (url.pathname || '').slice(1) || env.PGDATABASE || 'postgres',
     user            : o.user || o.username || auth[0] || env.PGUSERNAME || env.PGUSER || osUsername(),
     pass            : o.pass || o.password || auth[1] || env.PGPASSWORD || '',
-    max             : o.max || url.query.max || 10,
+    max             : o.max || (url && url.query.max) || 10,
     types           : o.types || {},
     ssl             : o.ssl || url.ssl || false,
     idle_timeout    : o.idle_timeout || url.query.idle_timeout || env.PGIDLE_TIMEOUT || warn(o.timeout),
@@ -540,6 +540,24 @@ function parseOptions(a, b) {
   },
     mergeUserTypes(o.types)
   )
+}
+
+function parseUrl(url, env) {
+  if (typeof url !== 'string')
+    return { url: { query: {} } }
+
+  let $ = url
+  $ = $.slice($.indexOf('://') + 3)
+  $ = $.split(/[?/]/)[0]
+  $ = $.slice($.indexOf('@') + 1)
+
+  const hosts = $.split(',')
+
+  return {
+    url: Url.parse(url.replace($, hosts[0]), true),
+    hosts: hosts.length > 1 && hosts.map(x => x.split(':')[0]),
+    ports: hosts.length > 1 && hosts.map(x => x.split(':')[1] || env.PGPORT || 5432)
+  }
 }
 
 function warn(x) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -556,7 +556,7 @@ function parseOptions(a, b) {
     pass            : o.pass || o.password || auth[1] || env.PGPASSWORD || '',
     max             : o.max || (url && url.query.max) || 10,
     types           : o.types || {},
-    ssl             : o.ssl || url.ssl || false,
+    ssl             : o.ssl || url.query.ssl || false,
     idle_timeout    : o.idle_timeout || url.query.idle_timeout || env.PGIDLE_TIMEOUT || warn(o.timeout),
     connect_timeout : o.connect_timeout || url.query.connect_timeout || env.PGCONNECT_TIMEOUT || 30,
     no_prepare      : o.no_prepare,

--- a/lib/index.js
+++ b/lib/index.js
@@ -564,7 +564,7 @@ function parseOptions(a, b) {
     onparameter     : o.onparameter,
     transform       : Object.assign({}, o.transform),
     connection      : Object.assign({ application_name: 'postgres.js' }, o.connection),
-    target_session_attrs: o.target_session_attrs || env.PGTARGETSESSIONATTRS,
+    target_session_attrs: o.target_session_attrs || url.query.target_session_attrs || env.PGTARGETSESSIONATTRS,
     debug           : o.debug
   },
     mergeUserTypes(o.types)

--- a/tests/index.js
+++ b/tests/index.js
@@ -53,15 +53,6 @@ t('Connects with no options', async() => {
   return [1, result]
 })
 
-not('Insert array of int', async() => {
-  await sql`create table test (x int[])`
-
-  return [
-    (await sql`insert into test (x) values (${ sql.array([1, 2, 3]) }) returning x`)[0].x.join(''),
-    '123'
-  ]
-})
-
 t('Uses default database without slash', async() => {
   const sql = postgres('postgres://localhost')
   return [sql.options.user, sql.options.database]

--- a/tests/index.js
+++ b/tests/index.js
@@ -1128,19 +1128,19 @@ t('Multiple hosts', {
   timeout: 10000
 }, async() => {
   const sql = postgres('postgres://localhost:5432,localhost:5433')
+      , result = []
 
   const a = (await sql`show data_directory`)[0].data_directory
-
+  result.push((await sql`select setting as x from pg_settings where name = 'port'`)[0].x)
   cp.execSync('pg_ctl stop -D "' + a + '"')
 
   const b = (await sql`show data_directory`)[0].data_directory
-
+  result.push((await sql`select setting as x from pg_settings where name = 'port'`)[0].x)
   cp.execSync('pg_ctl start -D "' + a + '" -w -l "' + a + '/postgresql.log"')
   cp.execSync('pg_ctl stop -D "' + b + '"')
 
-  await sql`select 1 as x`
-
+  result.push((await sql`select setting as x from pg_settings where name = 'port'`)[0].x)
   cp.execSync('pg_ctl start -o "-p 5433" -D "' + b + '" -w -l "' + b + '/postgresql.log"')
 
-  return [1, 1]
+  return ['5432,5433,5432', result.join(',')]
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,15 +17,15 @@ declare function postgres<T extends JSToPostgresTypeMap>(url: string, options?: 
  */
 interface BaseOptions<T extends JSToPostgresTypeMap> {
   /** Postgres ip address or domain name */
-  host: string;
+  host: string | string[];
   /** Postgres server port */
-  port: number;
+  port: number | number[];
   /** Name of database to connect to */
   database: string;
   /** Username of database user */
-  username: string;
+  user: string;
   /** True; or options for tls.connect */
-  ssl: boolean | object;
+  ssl: 'require' | 'prefer' | boolean | object;
   /** Max number of connections */
   max: number;
   /** Idle connection timeout in seconds */
@@ -34,6 +34,8 @@ interface BaseOptions<T extends JSToPostgresTypeMap> {
   connect_timeout: number;
   /** Array of custom types; see more below */
   types: PostgresTypeList<T>;
+  /** Disable prepared mode */
+  no_prepare: boolean;
   /** Defaults to console.log */
   onnotice: (notice: postgres.Notice) => void;
   /** (key; value) when server param change */
@@ -117,7 +119,7 @@ declare namespace postgres {
    */
   function toKebab(str: string): string;
 
-  const BigInt: PostgresType<(number: BigInt) => string>;
+  const BigInt: PostgresType<(number: bigint) => string>;
 
   interface ConnectionParameters {
     /** Default application_name */
@@ -127,6 +129,10 @@ declare namespace postgres {
   }
 
   interface Options<T extends JSToPostgresTypeMap> extends Partial<BaseOptions<T>> {
+    /** @inheritdoc */
+    host?: string;
+    /** @inheritdoc */
+    port?: number;
     /** unix socket path (usually '/tmp') */
     path?: string | (() => string);
     /** Password of database user (an alias for `password`) */
@@ -136,12 +142,16 @@ declare namespace postgres {
     /** Name of database to connect to (an alias for `database`) */
     db?: Options<T>['database'];
     /** Username of database user (an alias for `username`) */
-    user?: Options<T>['username'];
+    username?: Options<T>['user'];
     /** Postgres ip address or domain name (an alias for `host`) */
     hostname?: Options<T>['host'];
   }
 
   interface ParsedOptions<T extends JSToPostgresTypeMap> extends BaseOptions<T> {
+    /** @inheritdoc */
+    host: string[];
+    /** @inheritdoc */
+    port: number[];
     /** @inheritdoc */
     pass: null;
     serializers: { [oid: number]: T[keyof T] };


### PR DESCRIPTION
Multiple hosts can be specified like in [psql](https://www.postgresql.org/docs/13/libpq-connect.html#LIBPQ-MULTIPLE-HOSTS).

It's either done through the connection string, or through arrays in the host and port parameters.