### PR TITLE
fix(listen): makes sure unlisten returns a reference to conn result

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -341,15 +341,19 @@ function Postgres(a, b) {
 
     if (channel in listeners) {
       listeners[channel].push(fn)
-      return Promise.resolve(Object.assign({}, listener.result, { unlisten }))
+      return Promise.resolve(Object.create(listener.result, {
+        unlisten: { value: unlisten }
+      }))
     }
 
     listeners[channel] = [fn]
 
     return query({ raw: true }, listener.conn, 'listen ' + escape(channel))
       .then((result) => {
-        listener.result = result
-        return Object.assign({}, listener.result, { unlisten })
+        Object.assign(listener.result, result)
+        return Object.create(listener.result, {
+          unlisten: { value: unlisten }
+        })
       })
 
     function unlisten() {
@@ -382,8 +386,8 @@ function Postgres(a, b) {
     },
       options
     ))
-    listener = { conn, result: null }
-    all.push(conn)
+    listener = { conn, result: {} };
+    all.push(conn);
     return listener
   }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -593,6 +593,20 @@ t('listen reconnects', async() => {
   return ['ab', xs.join('')]
 })
 
+t('listen result reports correct connection state after reconnection', async() => {
+  const listener = postgres(options)
+      , xs = []
+
+  const result = await listener.listen('test', x => xs.push(x))
+  const initialPid = result.state.pid
+  await sql.notify('test', 'a')
+  await sql`select pg_terminate_backend(${ initialPid }::int)`
+  await delay(50)
+  listener.end()
+
+  return [result.state.pid, initialPid]
+})
+
 t('unlisten removes subscription', async() => {
   const listener = postgres(options)
       , xs = []

--- a/tests/index.js
+++ b/tests/index.js
@@ -604,7 +604,7 @@ t('listen result reports correct connection state after reconnection', async() =
   await delay(50)
   listener.end()
 
-  return [result.state.pid, initialPid]
+  return [result.state.pid !== initialPid, true]
 })
 
 t('unlisten removes subscription', async() => {


### PR DESCRIPTION
Eventually, this allows to get the new pid of pg connection after `listen` reconnects.

**Follow up PR** for #155
**Issue in tests**: how can I test unequality in tests?

```js
t('listen result reports correct connection state after reconnection', async() => {
  const listener = postgres(options)
      , xs = []

  const result = await listener.listen('test', x => xs.push(x))
  const initialPid = result.state.pid
  await sql.notify('test', 'a')
  await sql`select pg_terminate_backend(${ initialPid }::int)`
  await delay(50)
  listener.end()

  return [result.state.pid, initialPid]
})
```
