### PR TITLE
Adding in sql.raw method to allow postgres methods in template values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -513,15 +513,21 @@ function Postgres(a, b) {
   }
 
   function addValue(x, xargs, types) {
-    const type = getType(x)
-        , i = types.push(type.type)
+    console.log(x);
+    
+    const type = getType(x), 
+          i = type.type === -1 ? types.length : types.push(type.type)
 
     if (i > 65534)
       throw errors.generic({ message: 'Max number of parameters (65534) exceeded', code: 'MAX_PARAMETERS_EXCEEDED' })
 
-    xargs.push(type)
-    return '$' + i
-  }
+    if (type.type === -1) {
+      return type.value
+    } else {
+      xargs.push(type)
+      return '$' + i
+    }
+  }}
 
   function getType(x) {
     if (x == null)

--- a/lib/index.js
+++ b/lib/index.js
@@ -513,8 +513,6 @@ function Postgres(a, b) {
   }
 
   function addValue(x, xargs, types) {
-    console.log(x);
-    
     const type = getType(x), 
           i = type.type === -1 ? types.length : types.push(type.type)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -277,7 +277,8 @@ function Postgres(a, b) {
       unsafe,
       array,
       file,
-      json
+      json,
+      raw
     })
 
     function notify(channel, payload) {
@@ -286,6 +287,10 @@ function Postgres(a, b) {
 
     function unsafe(xs, args) {
       return query({ raw: true, simple: !args, dynamic: true }, connection || getConnection(), xs, args || [])
+    }
+
+    function raw(str) {
+      return { type: -1, value: str }
     }
 
     function file(path, args, options = {}) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -525,7 +525,7 @@ function Postgres(a, b) {
       xargs.push(type)
       return '$' + i
     }
-  }}
+  }
 
   function getType(x) {
     if (x == null)


### PR DESCRIPTION
My use case for this was this, which is does't seem like there's a way to do currently. 

```
sql`
    INSERT INTO table (
        id,
        name
    ) VALUES (
        ${ item.id || sql.raw("DEFAULT") },
        ${ item.name }
    )
    ON CONFLICT ON CONSTRAINT table_pkey
    DO UPDATE SET
        name" = ${ item.name }
`
```