### PR TITLE
Fix Markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ const sql = postgres()
 | `username`        | `PGUSERNAME` or `PGUSER` |
 | `password`        | `PGPASSWORD`             |
 | `idle_timeout`    | `PGIDLE_TIMEOUT`         |
-' `connect_timeout` | `PGCONNECT_TIMEOUT`      |
+| `connect_timeout` | `PGCONNECT_TIMEOUT`      |
 
 ## Query ```sql` ` -> Promise```
 


### PR DESCRIPTION
The apostrophe shows up in the readme:

![Screen Shot 2021-05-03 at 09 44 52](https://user-images.githubusercontent.com/1935696/116852311-60d6ec80-abf4-11eb-85b0-688a1716e84b.png)
