### PR TITLE
fix(cursor): make sure the last batch of rows is not lost - fixes #150, #81

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -75,18 +75,15 @@ function Connection(options = {}) {
   }
 
   function oncomplete() {
-    if (backend.query.cursor) {
-      const length = backend.query.result.length
-      if (length && length < backend.query.cursor.rows) {
-        new Promise(r => r(backend.query.cursor(
-          backend.query.cursor.rows === 1 ? backend.query.result[0] : backend.query.result
-        ))).then(() => socket.write(frontend.Close())).catch(err => {
-          backend.query.reject(err)
-          socket.write(frontend.Close())
-        })
-      } else {
+    if (backend.query.cursor && backend.query.result.length) {
+      new Promise(r => r(backend.query.cursor(
+        backend.query.cursor.rows === 1 ? backend.query.result[0] : backend.query.result
+      ))).then(() => socket.write(frontend.Close())).catch(err => {
+        backend.query.reject(err)
         socket.write(frontend.Close())
-      }
+      })
+    } else if (backend.query.cursor) {
+      socket.write(frontend.Close())
     }
   }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -75,7 +75,19 @@ function Connection(options = {}) {
   }
 
   function oncomplete() {
-    backend.query.cursor && socket.write(frontend.Close())
+    if (backend.query.cursor) {
+      const length = backend.query.result.length
+      if (length && length < backend.query.cursor.rows) {
+        new Promise(r => r(backend.query.cursor(
+          backend.query.cursor.rows === 1 ? backend.query.result[0] : backend.query.result
+        ))).then(() => socket.write(frontend.Close())).catch(err => {
+          backend.query.reject(err)
+          socket.write(frontend.Close())
+        })
+      } else {
+        socket.write(frontend.Close())
+      }
+    }
   }
 
   function onparse() {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -78,8 +78,12 @@ function Connection(options = {}) {
     if (backend.query.cursor && backend.query.result.length) {
       new Promise(r => r(backend.query.cursor(
         backend.query.cursor.rows === 1 ? backend.query.result[0] : backend.query.result
-      ))).then(() => socket.write(frontend.Close())).catch(err => {
+      ))).then(() => {
+        backend.query.result.length = 0
+        socket.write(frontend.Close())
+      }).catch(err => {
         backend.query.reject(err)
+        backend.query.result.length = 0
         socket.write(frontend.Close())
       })
     } else if (backend.query.cursor) {


### PR DESCRIPTION
Fixes #150, fixes #81.
There is no portal suspended indicator in these use-cases as it only appears if an Execute message's row-count limit was reached.
In these cases it is not reached since returned rows are less than the row-count limit, so the cursor's callback is called with the last batch of rows on command complete.