### PR TITLE
Add raw() method - fixes #194

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ const sql = postgres()
 
 ## Query ```sql` ` -> Promise```
 
-A query will always return a `Promise` which resolves to a results array `[...]{ count, command }`. Destructuring is great to immediately access the first element.
+A query will always return a `Promise` which resolves to a results array `[...]{ count, command, columns }`. Destructuring is great to immediately access the first element.
 
 ```js
 
@@ -277,6 +277,12 @@ await sql`
 })
 
 ```
+
+## Raw ```sql``.raw()```
+
+Using `.raw()` will return rows as an array with `Buffer` values for each column, instead of objects.
+
+This can be useful to receive identical named columns, or for specific performance / transformation reasons. The column definitions are still included on the result array with access to parsers for each column.
 
 ## Listen and notify
 

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -100,7 +100,7 @@ function Backend({
     let column
     let value
 
-    const row = {}
+    const row = backend.query.raw ? new Array(backend.query.statement.columns.length) : {}
     for (let i = 0; i < backend.query.statement.columns.length; i++) {
       column = backend.query.statement.columns[i]
       length = x.readInt32BE(index)
@@ -108,13 +108,17 @@ function Backend({
 
       value = length === -1
         ? null
-        : column.parser === undefined
-          ? x.toString('utf8', index, index += length)
-          : column.parser.array === true
-            ? column.parser(x.toString('utf8', index + 1, index += length))
-            : column.parser(x.toString('utf8', index, index += length))
+        : backend.query.raw
+          ? x.slice(index, index += length)
+          : column.parser === undefined
+            ? x.toString('utf8', index, index += length)
+            : column.parser.array === true
+              ? column.parser(x.toString('utf8', index + 1, index += length))
+              : column.parser(x.toString('utf8', index, index += length))
 
-      row[column.name] = transform.value ? transform.value(value) : value
+      backend.query.raw
+        ? (row[i] = value)
+        : (row[column.name] = transform.value ? transform.value(value) : value)
     }
 
     backend.query.stream

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ function Postgres(a, b) {
     , listener
 
   function postgres(xs) {
-    return query({ prepare: options.prepare }, getConnection(), xs, Array.from(arguments).slice(1))
+    return query({ tagged: true, prepare: options.prepare }, getConnection(), xs, Array.from(arguments).slice(1))
   }
 
   Object.assign(postgres, {
@@ -124,7 +124,7 @@ function Postgres(a, b) {
       }, connection)
     })
 
-    query({ raw: true }, connection, begin || savepoint)
+    query({}, connection, begin || savepoint)
       .then(() => {
         const result = fn(scoped)
         return Array.isArray(result)
@@ -137,7 +137,7 @@ function Postgres(a, b) {
           : resolve(x)
       )
       .catch((err) => {
-        query({ raw: true }, connection,
+        query({}, connection,
           begin
             ? 'rollback'
             : 'rollback to ' + savepoint
@@ -150,7 +150,7 @@ function Postgres(a, b) {
       }))
 
     function scoped(xs) {
-      return query({}, connection, xs, Array.from(arguments).slice(1))
+      return query({ tagged: true }, connection, xs, Array.from(arguments).slice(1))
     }
   }
 
@@ -168,7 +168,7 @@ function Postgres(a, b) {
   function query(query, connection, xs, args) {
     query.origin = options.debug ? new Error().stack : cachedError(xs)
     query.prepare = 'prepare' in query ? query.prepare : options.prepare
-    if (!query.raw && (!Array.isArray(xs) || !Array.isArray(xs.raw)))
+    if (query.tagged && (!Array.isArray(xs) || !Array.isArray(xs.raw)))
       return nested(xs, args)
 
     const promise = new Promise((resolve, reject) => {
@@ -206,7 +206,7 @@ function Postgres(a, b) {
 
   function send(connection, query, xs, args) {
     connection
-      ? process.nextTick(connection.send, query, query.raw ? parseRaw(query, xs, args) : parse(query, xs, args))
+      ? process.nextTick(connection.send, query, query.tagged ? parseTagged(query, xs, args) : parseUnsafe(query, xs, args))
       : queries.push({ query, xs, args })
   }
 
@@ -241,7 +241,7 @@ function Postgres(a, b) {
   function fetchArrayTypes(connection) {
     return arrayTypesPromise || (arrayTypesPromise =
       new Promise((resolve, reject) => {
-        send(connection, { resolve, reject, raw: true, prepare: false, origin: new Error().stack }, `
+        send(connection, { resolve, reject, tagged: false, prepare: false, origin: new Error().stack }, `
           select b.oid, b.typarray
           from pg_catalog.pg_type a
           left join pg_catalog.pg_type b on b.oid = a.typelem
@@ -286,7 +286,7 @@ function Postgres(a, b) {
 
     function unsafe(xs, args, queryOptions) {
       const prepare = queryOptions && queryOptions.prepare || false
-      return query({ raw: true, simple: !args, prepare }, connection || getConnection(), xs, args || [])
+      return query({ simple: !args, prepare }, connection || getConnection(), xs, args || [])
     }
 
     function file(path, args, options = {}) {
@@ -299,7 +299,7 @@ function Postgres(a, b) {
         options.cache = true
 
       const file = files[path]
-      const q = { raw: true, simple: !args }
+      const q = { tagged: false, simple: !args }
 
       if (options.cache && typeof file === 'string')
         return query(q, connection || getConnection(), file, args || [])
@@ -325,6 +325,7 @@ function Postgres(a, b) {
   }
 
   function addMethods(promise, query) {
+    promise.raw = () => (query.raw = true, promise)
     promise.stream = (fn) => (query.stream = fn, promise)
     promise.cursor = (rows, fn) => {
       if (typeof rows === 'function') {
@@ -350,7 +351,7 @@ function Postgres(a, b) {
 
     listeners[channel] = [fn]
 
-    return query({ raw: true }, listener.conn, 'listen ' + escape(channel))
+    return query({}, listener.conn, 'listen ' + escape(channel))
       .then((result) => {
         Object.assign(listener.result, result)
         return Object.create(listener.result, {
@@ -368,7 +369,7 @@ function Postgres(a, b) {
         return Promise.resolve()
 
       delete listeners[channel]
-      return query({ raw: true }, getListener().conn, 'unlisten ' + escape(channel)).then(() => undefined)
+      return query({}, getListener().conn, 'unlisten ' + escape(channel)).then(() => undefined)
     }
   }
 
@@ -409,7 +410,7 @@ function Postgres(a, b) {
     .then(() => clearTimeout(destroy))
   }
 
-  function parseRaw(query, str, args = []) {
+  function parseUnsafe(query, str, args = []) {
     const types = []
         , xargs = []
 
@@ -422,7 +423,7 @@ function Postgres(a, b) {
     }
   }
 
-  function parse(query, xs, args = []) {
+  function parseTagged(query, xs, args = []) {
     const xargs = []
         , types = []
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -1321,3 +1321,19 @@ t('Escaping supports schemas and tables', async() => {
     await sql`drop schema a`
   ]
 })
+
+t('Raw method returns rows as arrays', async() => {
+  const [x] = await sql`select 1`.raw()
+  return [
+    Array.isArray(x),
+    true
+  ]
+})
+
+t('Raw method returns values unparsed as Buffer', async() => {
+  const [[x]] = await sql`select 1`.raw()
+  return [
+    x instanceof Buffer,
+    true
+  ]
+})


### PR DESCRIPTION
The raw method returns rows as arrays of `null | Buffer` columns instead of objects. This allows some performance gains for specific scenarios and also retrieval of columns with the same name.

I'm thinking an argument with properties can be added in the future if for instance you'd like to have the values parsed but still rows as arrays etc.

Would you be interested in making the types for this @Minigugus ?

Documentation for `.raw()` also needs to be added to the before merging this.