### PR TITLE
Prevent obscuring errors when querying pg_catalog

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -241,7 +241,7 @@ function Postgres(a, b) {
   function fetchArrayTypes(connection) {
     return arrayTypesPromise || (arrayTypesPromise =
       new Promise((resolve, reject) => {
-        send(connection, { resolve, reject, raw: true, prepare: false }, `
+        send(connection, { resolve, reject, raw: true, prepare: false, origin: '' }, `
           select b.oid, b.typarray
           from pg_catalog.pg_type a
           left join pg_catalog.pg_type b on b.oid = a.typelem

--- a/lib/index.js
+++ b/lib/index.js
@@ -241,7 +241,7 @@ function Postgres(a, b) {
   function fetchArrayTypes(connection) {
     return arrayTypesPromise || (arrayTypesPromise =
       new Promise((resolve, reject) => {
-        send(connection, { resolve, reject, raw: true, prepare: false, origin: '' }, `
+        send(connection, { resolve, reject, raw: true, prepare: false, origin: new Error().stack }, `
           select b.oid, b.typarray
           from pg_catalog.pg_type a
           left join pg_catalog.pg_type b on b.oid = a.typelem


### PR DESCRIPTION
## What

Ensures if there is any postgres errors when invoking `fetchArrayTypes` that the original error is not obscured.
I don't have a solid understanding of the internals, so I simply added the missing property.  There may be a better way.

## How to test

- `revoke all on all tables in schema pg_catalog from public;`
- Run a simple query in postgres.js, e.g. `select 1`
- You should get a postgres permissions error

## Original Error

> Uncaught Exception: TypeError: Cannot read property 'replace' of undefined

## Expected Error

> PostgresError: permission denied for table pg_type

Fixes #202 