### PR TITLE
Subscribe to changes using logical replication

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,8 @@
 {
   "root": true,
   "env": {
-    "node": true,
-    "es6": true
+    "es2020": true,
+    "node": true
   },
   "parserOptions": {
     "ecmaVersion": 9,

--- a/README.md
+++ b/README.md
@@ -463,6 +463,12 @@ sql.file(path.join(__dirname, 'query.sql'), [], {
 
 ```
 
+## Realtime insert, update, delete `subscribe(pattern, fn)`
+
+Postgres.js implements the logical replication protocol of PostgreSQL to support subscription to realtime information about `insert`, `update` and `delete` operations.
+
+
+
 ## Transactions
 
 
@@ -532,6 +538,7 @@ sql.begin(async sql => {
 ```
 
 Do note that you can often achieve the same result using [`WITH` queries (Common Table Expressions)](https://www.postgresql.org/docs/current/queries-with.html) instead of using transactions.
+
 
 ## Custom Types
 

--- a/README.md
+++ b/README.md
@@ -463,11 +463,51 @@ sql.file(path.join(__dirname, 'query.sql'), [], {
 
 ```
 
-## Realtime insert, update, delete `subscribe(pattern, fn)`
+## Subscribe / Realtime
 
-Postgres.js implements the logical replication protocol of PostgreSQL to support subscription to realtime information about `insert`, `update` and `delete` operations.
+Postgres.js implements the logical replication protocol of PostgreSQL to support subscription to realtime updates of `insert`, `update` and `delete` operations.
 
+> **NOTE** To make this work you must [create the proper publications in your database](https://www.postgresql.org/docs/current/sql-createpublication.html), enable logical replication by setting `wal_level = logical` in `postgresql.conf` and connect using either a replication or superuser.
 
+### Quick start
+
+#### Create a publication (eg. in migration)
+```sql
+CREATE PUBLICATION alltables FOR ALL TABLES
+```
+
+#### Subscribe to updates
+```js
+const sql = postgres({ publications: 'alltables' })
+
+const { unsubscribe } = await sql.subscribe('insert:events', row =>
+  // tell about new event row over eg. websockets or do something else
+)
+```
+
+### Subscribe pattern
+
+You can subscribe to specific operations, tables or even rows with primary keys.
+
+### `operation`      `:` `schema` `.` `table` `=` `primary_key`
+
+**`operation`** is one of ``` * | insert | update | delete ``` and defaults to `*`
+
+**`schema`** defaults to `public.`
+
+**`table`** is a specific table name and defaults to `*`
+
+**`primary_key`** can be used to only subscribe to specific rows
+
+#### Examples
+
+```js
+sql.subscribe('*',                () => /* everything */ )
+sql.subscribe('insert',           () => /* all inserts */ )
+sql.subscribe('*:users',          () => /* all operations on the public.users table */ )
+sql.subscribe('delete:users',     () => /* all deletes on the public.users table */ )
+sql.subscribe('update:users=1',   () => /* all updates on the users row with a primary key = 1 */ )
+```
 
 ## Transactions
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const Url = require('url')
 const Stream = require('stream')
 const Connection = require('./connection.js')
 const Queue = require('./queue.js')
+const Subscribe = require('./subscribe.js')
 const { errors, PostgresError } = require('./errors.js')
 const {
   mergeUserTypes,
@@ -59,6 +60,7 @@ function Postgres(a, b) {
   const options = parseOptions(a, b)
 
   const max = Math.max(1, options.max)
+      , subscribe = Subscribe(Postgres, a, b)
       , transform = options.transform
       , connections = Queue()
       , all = []
@@ -82,6 +84,7 @@ function Postgres(a, b) {
   Object.assign(postgres, {
     options: Object.assign({}, options, { pass: null }),
     parameters: {},
+    subscribe,
     listen,
     begin,
     end
@@ -259,7 +262,7 @@ function Postgres(a, b) {
   function fetchArrayTypes(connection) {
     return arrayTypesPromise || (arrayTypesPromise =
       new Promise((resolve, reject) => {
-        send(connection, { resolve, reject, tagged: false, prepare: false, origin: new Error().stack }, `
+        send(connection, { resolve, reject, simple: true, tagged: false, prepare: false, origin: new Error().stack }, `
           select b.oid, b.typarray
           from pg_catalog.pg_type a
           left join pg_catalog.pg_type b on b.oid = a.typelem
@@ -397,8 +400,8 @@ function Postgres(a, b) {
           : query.writable.push({ chunk, callback })
       },
       destroy(error, callback) {
-        query.writable.push({ error })
         callback(error)
+        query.writable.push({ error })
       },
       final(callback) {
         if (error)
@@ -472,10 +475,16 @@ function Postgres(a, b) {
     let destroy
 
     return ended = Promise.race([
-      Promise.resolve(arrayTypesPromise).then(() => Promise.all(all.map(c => c.end())))
+      Promise.resolve(arrayTypesPromise).then(() => Promise.all(
+        (subscribe.sql ? [subscribe.sql.end({ timeout: 0 })] : []).concat(all.map(c => c.end()))
+      ))
     ].concat(
       timeout === 0 || timeout > 0
-        ? new Promise(r => destroy = setTimeout(() => (all.map(c => c.destroy()), r()), timeout * 1000))
+        ? new Promise(r => destroy = setTimeout(() => (
+          subscribe.sql && subscribe.sql.end({ timeout }),
+          all.map(c => c.destroy()),
+          r()
+        ), timeout * 1000))
         : []
     ))
     .then(() => clearTimeout(destroy))

--- a/lib/subscribe.js
+++ b/lib/subscribe.js
@@ -1,0 +1,210 @@
+module.exports = function(postgres, a, b) {
+  const listeners = new Map()
+
+  let connection
+
+  return async function subscribe(event, fn) {
+    event = parseEvent(event)
+
+    const options = typeof a === 'string' ? b : a || {}
+    options.max = 1
+    options.connection = {
+      ...options.connection,
+      replication: 'database'
+    }
+
+    const sql = postgres(a, b)
+
+    !connection && (subscribe.sql = sql, connection = init(sql, options.publications))
+
+    const fns = listeners.has(event)
+      ? listeners.get(event).add(fn)
+      : listeners.set(event, new Set([fn]))
+
+    const unsubscribe = () => {
+      fns.delete(fn)
+      fns.size === 0 && listeners.delete(event)
+    }
+
+    return connection.then(() => ({ unsubscribe }))
+  }
+
+  async function init(sql, publications = 'alltables') {
+    if (!publications)
+      throw new Error('Missing publication names')
+
+    const slot = 'postgresjs_' + Math.random().toString(36).slice(2)
+    const [x] = await sql.unsafe(
+      `CREATE_REPLICATION_SLOT ${ slot } TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT`
+    )
+
+    const stream = sql.unsafe(
+      `START_REPLICATION SLOT ${ slot } LOGICAL ${
+        x.consistent_point
+      } (proto_version '1', publication_names '${ publications }')`
+    ).writable()
+
+    const state = {
+      lsn: Buffer.concat(x.consistent_point.split('/').map(x => Buffer.from(('00000000' + x).slice(-8), 'hex')))
+    }
+
+    stream.on('data', data)
+
+    function data(x) {
+      if (x[0] === 0x77)
+        parse(x.slice(25), state, sql.options.parsers, handle)
+      else if (x[0] === 0x6b && x[17])
+        pong()
+    }
+
+    function handle(a, b) {
+      const path = b.relation.schema + '.' + b.relation.table
+      call('*', a, b)
+      call('*:' + path, a, b)
+      b.relation.keys.length && call('*:' + path + '=' + b.relation.keys.map(x => a[x.name]), a, b)
+      call(b.command, a, b)
+      call(b.command + ':' + path, a, b)
+      b.relation.keys.length && call(b.command + ':' + path + '=' + b.relation.keys.map(x => a[x.name]), a, b)
+    }
+
+    function pong() {
+      const x = Buffer.alloc(34)
+      x[0] = 'r'.charCodeAt(0)
+      x.fill(state.lsn, 1)
+      x.writeBigInt64BE(BigInt(Date.now() - Date.UTC(2000, 0, 1)) * BigInt(1000), 25)
+      stream.write(x)
+    }
+  }
+
+  function call(x, a, b) {
+    listeners.has(x) && listeners.get(x).forEach(fn => fn(a, b, x))
+  }
+}
+
+function Time(x) {
+  return new Date(Date.UTC(2000, 0, 1) + Number(x / BigInt(1000)))
+}
+
+function parse(x, state, parsers, handle) {
+  const char = (acc, [k, v]) => (acc[k.charCodeAt(0)] = v, acc)
+
+  Object.entries({
+    R: x => {  // Relation
+      let i = 1
+      const r = state[x.readInt32BE(i)] = {
+        schema: String(x.slice(i += 4, i = x.indexOf(0, i))) || 'pg_catalog',
+        table: String(x.slice(i + 1, i = x.indexOf(0, i + 1))),
+        columns: Array(x.readInt16BE(i += 2)),
+        keys: []
+      }
+      i += 2
+
+      let columnIndex = 0
+        , column
+
+      while (i < x.length) {
+        column = r.columns[columnIndex++] = {
+          key: x[i++],
+          name: String(x.slice(i, i = x.indexOf(0, i))),
+          type: x.readInt32BE(i += 1),
+          parser: parsers[x.readInt32BE(i)],
+          atttypmod: x.readInt32BE(i += 4)
+        }
+
+        column.key && r.keys.push(column)
+        i += 4
+      }
+    },
+    Y: () => { /* noop */ }, // Type
+    O: () => { /* noop */ }, // Origin
+    B: x => { // Begin
+      state.date = Time(x.readBigInt64BE(9))
+      state.lsn = x.slice(1, 9)
+    },
+    I: x => { // Insert
+      let i = 1
+      const relation = state[x.readInt32BE(i)]
+      const row = {}
+      tuples(x, row, relation.columns, i += 7)
+
+      handle(row, {
+        command: 'insert',
+        relation
+      })
+    },
+    D: x => { // Delete
+      let i = 1
+      const relation = state[x.readInt32BE(i)]
+      i += 4
+      const key = x[i] === 75
+      const row = key || x[i] === 79
+        ? {}
+        : null
+
+      tuples(x, row, key ? relation.keys : relation.columns, i += 3)
+
+      handle(row, {
+        command: 'delete',
+        relation,
+        key
+      })
+    },
+    U: x => { // Update
+      let i = 1
+      const relation = state[x.readInt32BE(i)]
+      i += 4
+      const key = x[i] === 75
+      const old = key || x[i] === 79
+        ? {}
+        : null
+
+      old && (i = tuples(x, old, key ? relation.keys : relation.columns, ++i))
+
+      const row = {}
+      i = tuples(x, row, relation.columns, i += 3)
+
+      handle(row, {
+        command: 'update',
+        relation,
+        key,
+        old
+      })
+    },
+    T: () => { /* noop */ }, // Truncate,
+    C: () => { /* noop */ }  // Commit
+  }).reduce(char, {})[x[0]](x)
+}
+
+function tuples(x, row, columns, xi) {
+  let type
+    , column
+
+  for (let i = 0; i < columns.length; i++) {
+    type = x[xi++]
+    column = columns[i]
+    row[column.name] = type === 110 // n
+      ? null
+      : type === 117 // u
+        ? undefined
+        : column.parser === undefined
+          ? x.toString('utf8', xi + 4, xi += 4 + x.readInt32BE(xi))
+          : column.parser.array === true
+            ? column.parser(x.toString('utf8', xi + 5, xi += 4 + x.readInt32BE(xi)))
+            : column.parser(x.toString('utf8', xi + 4, xi += 4 + x.readInt32BE(xi)))
+  }
+
+  return xi
+}
+
+function parseEvent(x) {
+  const xs = x.match(/^(\*|insert|update|delete)?:?([^.]+?\.?[^=]+)?=?(.+)?/i) || []
+
+  if (!xs)
+    throw new Error('Malformed subscribe pattern: ' + x)
+
+  const [, command, path, key] = xs
+
+  return (command || '*')
+       + (path ? ':' + (path.indexOf('.') === -1 ? 'public.' + path : path) : '')
+       + (key ? '=' + key : '')
+}


### PR DESCRIPTION
I've just finished implementing realtime capability to Postgres.js through logical replication, so you can subscribe to changes as simple as this:

### Create a publication (eg. in migration)
```sql
CREATE PUBLICATION alltables FOR ALL TABLES
```

### Subscribe to updates
```js
const sql = postgres({ publications: 'alltables' })

const { unsubscribe } = await sql.subscribe('insert:events', row =>
  // tell about new event row over eg. websockets or do something else
)
```

The pattern for subscribing is `[command]:[schema.table]=[primary_key]` where `command` is `insert | update | delete | *` and defaults to `*`. `schema.table` defaults to `*` and will prepend `public.` if schema is not defined. As the last thing `primary_key` can be used to only subscribe to a specific row. It's optimized to do the least amount of work depending on what you subscribe to, so I'm really excited to see what can be built with this.

Now I still have some tests and docs to write, but if anyone would like to take this branch for a spin I would love to hear what you think..