### PR TITLE
Expose PostgresError on module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ function notTagged() {
 }
 
 Object.assign(Postgres, {
+  PostgresError,
   toPascal,
   toCamel,
   toKebab,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -103,10 +103,10 @@ type UnwrapPromiseArray<T> = T extends any[] ? {
   [k in keyof T]: T[k] extends Promise<infer R> ? R : T[k]
 } : T;
 
-type PostgresErrorType = PostgresError
+type PostgresErrorType = typeof PostgresError
 
 declare namespace postgres {
-  type PostgresError = PostgresErrorType
+  export const PostgresError: PostgresErrorType;
 
   /**
    * Convert a string to Pascal case.


### PR DESCRIPTION
Fixes #226. @porsager I think it would be neater to just move `PostgresError` declaration into `postgres` namespace to avoid that intermediary `PostgresErrorType` and `const`. Didn't want to make too big of a change, so just went with that. Let me know if you want it in the namespace and I'll amend! 👍