### PR TITLE
remove time without time zone from date type cast

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -28,7 +28,7 @@ const types = module.exports.types = {
   },
   date: {
     to: 1184,
-    from: [1082, 1083, 1114, 1184],
+    from: [1082, 1114, 1184],
     serialize: x => x.toISOString(),
     parse: x => new Date(x)
   },


### PR DESCRIPTION
Time types are stored as strings that are not compatible in the `new Date` constructer. They don't need to be cast.