### PR TITLE
Fix and update types

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,11 +213,10 @@ return user // => User
 
 // NOTE:
 const [first, second]: [User?] = await sql`SELECT * FROM users WHERE id = ${id}` // fails: `second` does not exist on `[User?]`
-// vs
-const [first, second] = await sql<[User?]>`SELECT * FROM users WHERE id = ${id}` // ok but should fail
+const [first, second] = await sql<[User?]>`SELECT * FROM users WHERE id = ${id}` // don't fail : `second: User | undefined`
 ```
 
-All the public API is typed. Also, TypeScript support is still in beta. Feel free to open an issue if you have trouble with types.
+We do our best to type all the public API, however types are not always updated when features are added ou changed. Feel free to open an issue if you have trouble with types.
 
 ## forEach ```sql` `.forEach(fn) -> Promise```
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -9,8 +9,7 @@ import net from 'net'
 import fs from 'fs'
 import crypto from 'crypto'
 
-/** @type {import('../types')} */
-import postgres from '../src/index.js'
+import postgres from '..'
 const delay = ms => new Promise(r => setTimeout(r, ms))
 
 const rel = x => new URL(x, import.meta.url)

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@types/node": "^16"
+  }
+}


### PR DESCRIPTION
TypeScript definitions are missing a lot a features (mostly `.raw()`, `.readable()`, `.writable()`, `sql.subscribe()` and some new options)

I tried to fix them before the v2 release. I also added default values for options in their descriptions, it can be useful for options that fallback to an environment variable when missing. It might be cool to add more documentation too but I'm busy these days :confused: