### PR TITLE
Removed PathOrFileDescriptor type in types.d.ts which is undefined before ~Node 16.3

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -573,8 +573,8 @@ declare namespace postgres {
     begin<T>(options: string, cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
 
     array<T extends SerializableParameter[] = SerializableParameter[]>(value: T, type?: number): ArrayParameter<T>;
-    file<T extends readonly any[] = Row[]>(path: import('node:fs').PathOrFileDescriptor, options?: { cache?: boolean }): PendingQuery<AsRowList<T>>;
-    file<T extends readonly any[] = Row[]>(path: import('node:fs').PathOrFileDescriptor, args: SerializableParameter[], options?: { cache?: boolean }): PendingQuery<AsRowList<T>>;
+    file<T extends readonly any[] = Row[]>(path: string | Buffer | URL | number, options?: { cache?: boolean }): PendingQuery<AsRowList<T>>;
+    file<T extends readonly any[] = Row[]>(path: string | Buffer | URL | number, args: SerializableParameter[], options?: { cache?: boolean }): PendingQuery<AsRowList<T>>;
     json(value: any): Parameter;
   }
 


### PR DESCRIPTION
PathOrFileDescriptor resolves to `string | Buffer | URL | number` in newer versions of node. Can be seen here:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6d36b159c03dace2a85a6081c80326a26ccc8aae/types/node/fs.d.ts#L31