### PR TITLE
Fix unsubscribing 

### DIFF
--- a/src/subscribe.js
+++ b/src/subscribe.js
@@ -31,11 +31,11 @@ export default function Subscribe(postgres, options) {
 
     const fns = listeners.has(event)
       ? listeners.get(event).add(fn)
-      : listeners.set(event, new Set([fn]))
+      : listeners.set(event, new Set([fn])).get(event)
 
     const unsubscribe = () => {
-      fns.get(event).delete(fn)
-      fns.get(event).size === 0 && listeners.delete(event)
+      fns.delete(fn)
+      fns.size === 0 && listeners.delete(event)
     }
 
     return connection.then(x => (stream = x, { unsubscribe }))

--- a/src/subscribe.js
+++ b/src/subscribe.js
@@ -34,8 +34,8 @@ export default function Subscribe(postgres, options) {
       : listeners.set(event, new Set([fn]))
 
     const unsubscribe = () => {
-      fns.delete(fn)
-      fns.size === 0 && listeners.delete(event)
+      fns.get(event).delete(fn)
+      fns.get(event).size === 0 && listeners.delete(event)
     }
 
     return connection.then(x => (stream = x, { unsubscribe }))


### PR DESCRIPTION
Previously, unsubscribing was a no op because event listeneres were deleted from the wrong set.

Here is the script + command I was using for testing: `ps -eaf | grep walsender`
```JavaScript
import postgres from 'postgres'

const uri = 'env.PG_URI';
console.log(uri);
async function start() {

	const sql = postgres(uri, {
		// publications: 'custom_pub',
		fetch_types: false
	});
	const { unsubscribe: unsubscribe } = await sql.subscribe('*', function (row, { command: command, relation: relation, key: key, old: old }) {

		return console.log('event 1');
	});
	console.log("subscribed");
	return process.on('SIGINT', function () {

		console.log('unsub');
		return unsubscribe();
	});
};

start();

```