### PR TITLE
Fix type errors in TypeScript deno projects

### DIFF
--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -1,3 +1,6 @@
+import { Buffer } from 'https://deno.land/std@0.132.0/node/buffer.ts'
+import process from 'https://deno.land/std@0.132.0/node/process.ts'
+import { Readable, Writable } from 'https://deno.land/std@0.132.0/node/stream.ts'
 /**
  * Establish a connection to a PostgreSQL server.
  * @param options Connection options - default to the same as psql
@@ -430,12 +433,12 @@ declare namespace postgres {
     writable(options?: {
       highWaterMark?: number,
       start?: number
-    }): Promise<import('node:stream').Writable>;
+    }): Promise<Writable>;
     readable(options?: {
       highWaterMark?: number,
       start?: number,
       end?: number
-    }): Promise<import('node:stream').Readable>;
+    }): Promise<Readable>;
 
     close(): Promise<void>;
     tell(): Promise<void>;
@@ -515,8 +518,8 @@ declare namespace postgres {
   type RowList<T extends readonly any[]> = T & Iterable<NonNullable<T[number]>> & ResultQueryMeta<T['length'], keyof T[number]>;
 
   interface PendingQueryModifiers<TRow extends readonly any[]> {
-    readable(): import('node:stream').Readable;
-    writable(): import('node:stream').Writable;
+    readable(): Readable;
+    writable(): Writable;
 
     execute(): this;
     cancel(): void;

--- a/transpile.deno.js
+++ b/transpile.deno.js
@@ -13,7 +13,11 @@ ensureEmpty(src)
 ensureEmpty(types)
 ensureEmpty(tests)
 
-fs.writeFileSync(path.join(types, 'index.d.ts'), fs.readFileSync(path.join('types', 'index.d.ts')))
+fs.writeFileSync(
+  path.join(types, 'index.d.ts'),
+  transpile(fs.readFileSync(path.join('types', 'index.d.ts'), 'utf8'), 'index.d.ts', 'types')
+)
+
 fs.writeFileSync(
   path.join(root, 'README.md'),
   fs.readFileSync('README.md', 'utf8')
@@ -54,6 +58,10 @@ function transpile(x, name, folder) {
       x += '\n;window.addEventListener("unload", () => Deno.exit(process.exitCode))'
   }
 
+  const stream = x.includes('import(\'node:stream\')')
+    ? 'import { Readable, Writable } from \'' + std + 'node/stream.ts\'\n'
+    : ''
+
   const buffer = x.includes('Buffer')
     ? 'import { Buffer } from \'' + std + 'node/buffer.ts\'\n'
     : ''
@@ -70,7 +78,7 @@ function transpile(x, name, folder) {
     ? 'import { HmacSha256 } from \'' + std + 'hash/sha256.ts\'\n'
     : ''
 
-  return hmac + buffer + process + timers + x
+  return hmac + buffer + process + stream + timers + x
     .replace(
       /setTimeout\((.*)\)\.unref\(\)/g,
       '(window.timer = setTimeout($1), Deno.unrefTimer(window.timer), window.timer)'
@@ -84,6 +92,7 @@ function transpile(x, name, folder) {
       '(query.writable.push({ chunk }), callback())'
     )
     .replace(/.setKeepAlive\([^)]+\)/g, '')
+    .replace(/import\('node:stream'\)\./g, '')
     .replace(/import net from 'net'/, 'import { net } from \'../polyfills.js\'')
     .replace(/import tls from 'tls'/, 'import { tls } from \'../polyfills.js\'')
     .replace(/ from '([a-z_]+)'/g, ' from \'' + std + 'node/$1.ts\'')


### PR DESCRIPTION
Also transpile type definitions and add some missing imports for Readable and Writable streams.

Fixes #312.