### PR TITLE
Fix types for `.writable()` and `.readable()` to return promises

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -532,8 +532,8 @@ declare namespace postgres {
   type RowList<T extends readonly any[]> = T & Iterable<NonNullable<T[number]>> & ResultQueryMeta<T['length'], keyof T[number]>;
 
   interface PendingQueryModifiers<TRow extends readonly any[]> {
-    readable(): Readable;
-    writable(): Writable;
+    readable(): Promise<Readable>;
+    writable(): Promise<Writable>;
 
     execute(): this;
     cancel(): void;


### PR DESCRIPTION
See actual js implementation where the functions are async and return promises:
https://github.com/porsager/postgres/blob/56873c24de6311fba87818dfa478aa06f09756c2/src/query.js#L57-L69

Currently, a work-around for the bugged typing looks something like:
```ts
  async function createMyTableWriteStream(): Promise<Writable> {
    const query = this.sql`COPY my_table FROM STDIN`;
    // type for `writeStream` is incorrectly specified as `Writable` rather than `Promise<Writable>`
    const writeStream = query.writable();
    // use `Promise.resolve` to unwrap the promise returned by `.writable()`
    return await Promise.resolve(writeStream);
  }
```

With this fix, the correct usage looks something like:
```ts
  async function createMyTableWriteStream(): Promise<Writable> {
    const query = this.sql`COPY my_table FROM STDIN`;
    return await query.writable();
  }
```