### PR TITLE
docs: add example of readable & writable COPY stream usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ await pipeline(userStream, query);
 
 ```js
 const { pipeline } = require('stream/promises')
-const { createWriteStream } = require('fs');
+const { createWriteStream } = require('fs')
 
 const query = await sql`copy users (name, age) to stdin`.readable()
 await pipeline(query, createWriteStream('output.tsv'))

--- a/README.md
+++ b/README.md
@@ -428,9 +428,9 @@ const result = await sql.file('query.sql', ['Murray', 68])
 
 ### Rows as Streams
 
-Postgres.js supports [`copy ...`](https://www.postgresql.org/docs/14/sql-copy.html) queries, which are exposed as [Node.js streams](https://nodejs.org/dist/latest-v16.x/docs/api/stream.html).
+Postgres.js supports [`copy ...`](https://www.postgresql.org/docs/14/sql-copy.html) queries, which are exposed as [Node.js streams](https://nodejs.org/api/stream.html).
 
-> **NOTE** This is a low-level API which does not provide any type safety. To make this work, you must match your [`copy query` parameters](https://www.postgresql.org/docs/14/sql-copy.html) correctly to your [Node.js stream read or write](https://nodejs.org/dist/latest-v16.x/docs/api/stream.html) code. Ensure [Node.js stream backpressure](https://nodejs.org/en/docs/guides/backpressuring-in-streams/) is handled correctly to avoid memory exhaustion.
+> **NOTE** This is a low-level API which does not provide any type safety. To make this work, you must match your [`copy query` parameters](https://www.postgresql.org/docs/14/sql-copy.html) correctly to your [Node.js stream read or write](https://nodejs.org/api/stream.html) code. Ensure [Node.js stream backpressure](https://nodejs.org/en/docs/guides/backpressuring-in-streams/) is handled correctly to avoid memory exhaustion.
 
 #### ```await sql`copy ... from stdin` -> Writable```
 
@@ -449,14 +449,30 @@ await pipeline(userStream, query);
 
 #### ```await sql`copy ... to stdin` -> Readable```
 
+##### stream pipeline
 ```js
 const { pipeline } = require('stream/promises')
 const { createWriteStream } = require('fs')
 
-const query = await sql`copy users (name, age) to stdin`.readable()
-await pipeline(query, createWriteStream('output.tsv'))
+const readableStream = await sql`copy users (name, age) to stdin`.readable()
+await pipeline(readableStream, createWriteStream('output.tsv'))
 // output.tsv content: `Murray\t68\nWalter\t80\n`
 ```
+
+##### for await...of
+```js
+const readableStream = await sql`
+  copy (
+    select name, age 
+    from users 
+    where age = 68
+  ) to stdin
+`.readable()
+for await (const chunk of readableStream) {
+  // chunk.toString() === `Murray\t68\n`
+}
+```
+
 
 ### Canceling Queries in Progress
 


### PR DESCRIPTION
Add documentation for the `<query>.writable()` and `<query>.readable()` APIs which are already covered in unit tests and typescript definitions, but not mentioned in the docs/readme.