### PR TITLE
docs: Convert CJS imports to ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ await sql`
 `.cursor(async([row]) => {
   // row = { x: 1 }
   await http.request('https://example.com/wat', { row })
-}
+})
 ```
 
 ##### for await...of
@@ -366,7 +366,7 @@ await sql`
   await Promise.all(rows.map(row =>
     http.request('https://example.com/wat', { row })
   ))
-}
+})
 ```
 
 If an error is thrown inside the callback function no more rows will be requested and the outer promise will reject with the thrown error.

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Postgres.js supports [`COPY ...`](https://www.postgresql.org/docs/14/sql-copy.ht
 #### ```await sql`copy ... from stdin`.writable() -> Writable```
 
 ```js
-const { pipeline } = require('stream/promises')
+import { pipeline } from 'node:stream/promises'
 
 // Stream of users with the default tab delimitated cells and new-line delimitated rows
 const userStream = Readable.from([
@@ -449,8 +449,8 @@ await pipeline(userStream, query);
 
 ##### Using Stream Pipeline
 ```js
-const { pipeline } = require('stream/promises')
-const { createWriteStream } = require('fs')
+import { pipeline } from 'node:stream/promises'
+import { createWriteStream } from 'node:fs'
 
 const readableStream = await sql`copy users (name, age) to stdout`.readable()
 await pipeline(readableStream, createWriteStream('output.tsv'))


### PR DESCRIPTION
Converted cjs imports to es and added `node:` protocol to avoid confusion. [more about `node:`](https://github.com/nodejs/node/issues/38343) 