### PR TITLE
fix: deno assertRejects compatibility

### DIFF
--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -227,9 +227,6 @@ declare namespace postgres {
     query: string;
     /** Only set when debug is enabled */
     parameters: any[];
-
-    // Disable user-side creation of PostgresError
-    private constructor();
   }
 
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -225,9 +225,6 @@ declare namespace postgres {
     query: string;
     /** Only set when debug is enabled */
     parameters: any[];
-
-    // Disable user-side creation of PostgresError
-    private constructor();
   }
 
   /**


### PR DESCRIPTION
`assertRejects` of Deno is defined as:

```
export function assertRejects<E extends Error = Error>(
  fn: () => Promise<unknown>,
  ErrorClass?: new (...args: any[]) => E,
  msgIncludes?: string,
  msg?: string,
): Promise<void>;
```

I suggest acknowledging `PostgresError` has a constructor by removing `private constructor()`. Please let me know if there are better approaches.

Thanks.