### PR TITLE
fix: include missing boolean type in JSONValue union

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -477,6 +477,7 @@ declare namespace postgres {
     | null
     | string
     | number
+    | boolean
     | Date // serialized as `string`
     | readonly JSONValue[]
     | { toJSON(): any } // `toJSON` called by `JSON.stringify`; not typing the return type, typings is strict enough anyway


### PR DESCRIPTION
This Pull Request adds `boolean` to the `JSONValue` type in `types/index.d.ts`.

<img width="859" alt="image" src="https://user-images.githubusercontent.com/7432943/169599201-b1e4efef-0291-4b85-b0c4-9913019af237.png">
