### PR TITLE
WIP: Remove js type inference

### DIFF
--- a/cjs/src/types.js
+++ b/cjs/src/types.js
@@ -211,15 +211,11 @@ const escapeIdentifier = module.exports.escapeIdentifier = function escape(str) 
 }
 
 const inferType = module.exports.inferType = function inferType(x) {
-  return (
-    x instanceof Parameter ? x.type :
-    x instanceof Date ? 1184 :
-    x instanceof Uint8Array ? 17 :
-    (x === true || x === false) ? 16 :
-    typeof x === 'bigint' ? 20 :
-    Array.isArray(x) ? inferType(x[0]) :
-    0
-  )
+  return x instanceof Parameter
+    ? x.type
+    : Array.isArray(x)
+      ? inferType(x[0])
+      : 0
 }
 
 const escapeBackslash = /\\/g

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -89,16 +89,16 @@ t('String', async() =>
 )
 
 t('Boolean false', async() =>
-  [false, (await sql`select ${ false } as x`)[0].x]
+  [false, (await sql`select ${ false }::bool as x`)[0].x]
 )
 
 t('Boolean true', async() =>
-  [true, (await sql`select ${ true } as x`)[0].x]
+  [true, (await sql`select ${ true }::bool as x`)[0].x]
 )
 
 t('Date', async() => {
   const now = new Date()
-  return [0, now - (await sql`select ${ now } as x`)[0].x]
+  return [0, now - (await sql`select ${ now }::timestamptz as x`)[0].x]
 })
 
 t('Json', async() => {
@@ -134,7 +134,8 @@ t('Array of String', async() =>
 
 t('Array of Date', async() => {
   const now = new Date()
-  return [now.getTime(), (await sql`select ${ sql.array([now, now, now]) } as x`)[0].x[2].getTime()]
+      , iso = now.toISOString()
+  return [now.getTime(), (await sql`select ${ sql.array([iso, iso, iso]) }::timestamptz[] as x`)[0].x[2].getTime()]
 })
 
 t('Nested array n2', async() =>
@@ -1034,10 +1035,7 @@ t('Multiple queries', async() => {
 })
 
 t('Multiple statements', async() =>
-  [2, await sql.unsafe(`
-    select 1 as x;
-    select 2 as a;
-  `).then(([, [x]]) => x.a)]
+  [2, await sql.unsafe(`select 1 as x;select 2 as a`).then(([, [x]]) => x.a)]
 )
 
 t('throws correct error when authentication fails', async() => {
@@ -1188,7 +1186,7 @@ t('Multiple Cursors', { timeout: 2 }, async() => {
 
 t('Cursor as async iterator', async() => {
   const order = []
-  for await (const [x] of sql`select generate_series(1,2) as x;`.cursor()) {
+  for await (const [x] of sql`select generate_series(1,2) as x`.cursor()) {
     order.push(x.x + 'a')
     await delay(10)
     order.push(x.x + 'b')
@@ -1199,7 +1197,7 @@ t('Cursor as async iterator', async() => {
 
 t('Cursor as async iterator with break', async() => {
   const order = []
-  for await (const xs of sql`select generate_series(1,2) as x;`.cursor()) {
+  for await (const xs of sql`select generate_series(1,2) as x`.cursor()) {
     order.push(xs[0].x + 'a')
     await delay(10)
     order.push(xs[0].x + 'b')
@@ -1519,7 +1517,7 @@ t('Recreate prepared statements on transformAssignedExpr error', { timeout: 1 },
 
 t('Throws correct error when retrying in transactions', async() => {
   await sql`create table test(x int)`
-  const error = await sql.begin(sql => sql`insert into test (x) values (${ false })`).catch(e => e)
+  const error = await sql.begin(sql => sql`insert into test (x) values (${ false }::bool)`).catch(e => e)
   return [
     error.code,
     '42804',

--- a/deno/README.md
+++ b/deno/README.md
@@ -890,7 +890,7 @@ const sql = postgres()
 
 ### Prepared statements
 
-Prepared statements will automatically be created for any queries where it can be inferred that the query is static. This can be disabled by using the `no_prepare` option. For instance — this is useful when [using PGBouncer in `transaction mode`](https://github.com/porsager/postgres/issues/93).
+Prepared statements will automatically be created for any queries where it can be inferred that the query is static. This can be disabled by using the `no_prepare` option. For instance — this is useful when [using PGBouncer in `transaction mode`](https://github.com/porsager/postgres/issues/93#issuecomment-656290493).
 
 ## Custom Types
 

--- a/deno/src/types.js
+++ b/deno/src/types.js
@@ -212,15 +212,11 @@ export const escapeIdentifier = function escape(str) {
 }
 
 export const inferType = function inferType(x) {
-  return (
-    x instanceof Parameter ? x.type :
-    x instanceof Date ? 1184 :
-    x instanceof Uint8Array ? 17 :
-    (x === true || x === false) ? 16 :
-    typeof x === 'bigint' ? 20 :
-    Array.isArray(x) ? inferType(x[0]) :
-    0
-  )
+  return x instanceof Parameter
+    ? x.type
+    : Array.isArray(x)
+      ? inferType(x[0])
+      : 0
 }
 
 const escapeBackslash = /\\/g

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -91,16 +91,16 @@ t('String', async() =>
 )
 
 t('Boolean false', async() =>
-  [false, (await sql`select ${ false } as x`)[0].x]
+  [false, (await sql`select ${ false }::bool as x`)[0].x]
 )
 
 t('Boolean true', async() =>
-  [true, (await sql`select ${ true } as x`)[0].x]
+  [true, (await sql`select ${ true }::bool as x`)[0].x]
 )
 
 t('Date', async() => {
   const now = new Date()
-  return [0, now - (await sql`select ${ now } as x`)[0].x]
+  return [0, now - (await sql`select ${ now }::timestamptz as x`)[0].x]
 })
 
 t('Json', async() => {
@@ -136,7 +136,8 @@ t('Array of String', async() =>
 
 t('Array of Date', async() => {
   const now = new Date()
-  return [now.getTime(), (await sql`select ${ sql.array([now, now, now]) } as x`)[0].x[2].getTime()]
+      , iso = now.toISOString()
+  return [now.getTime(), (await sql`select ${ sql.array([iso, iso, iso]) }::timestamptz[] as x`)[0].x[2].getTime()]
 })
 
 t('Nested array n2', async() =>
@@ -1036,10 +1037,7 @@ t('Multiple queries', async() => {
 })
 
 t('Multiple statements', async() =>
-  [2, await sql.unsafe(`
-    select 1 as x;
-    select 2 as a;
-  `).then(([, [x]]) => x.a)]
+  [2, await sql.unsafe(`select 1 as x;select 2 as a`).then(([, [x]]) => x.a)]
 )
 
 t('throws correct error when authentication fails', async() => {
@@ -1190,7 +1188,7 @@ t('Multiple Cursors', { timeout: 2 }, async() => {
 
 t('Cursor as async iterator', async() => {
   const order = []
-  for await (const [x] of sql`select generate_series(1,2) as x;`.cursor()) {
+  for await (const [x] of sql`select generate_series(1,2) as x`.cursor()) {
     order.push(x.x + 'a')
     await delay(10)
     order.push(x.x + 'b')
@@ -1201,7 +1199,7 @@ t('Cursor as async iterator', async() => {
 
 t('Cursor as async iterator with break', async() => {
   const order = []
-  for await (const xs of sql`select generate_series(1,2) as x;`.cursor()) {
+  for await (const xs of sql`select generate_series(1,2) as x`.cursor()) {
     order.push(xs[0].x + 'a')
     await delay(10)
     order.push(xs[0].x + 'b')
@@ -1521,7 +1519,7 @@ t('Recreate prepared statements on transformAssignedExpr error', { timeout: 1 },
 
 t('Throws correct error when retrying in transactions', async() => {
   await sql`create table test(x int)`
-  const error = await sql.begin(sql => sql`insert into test (x) values (${ false })`).catch(e => e)
+  const error = await sql.begin(sql => sql`insert into test (x) values (${ false }::bool)`).catch(e => e)
   return [
     error.code,
     '42804',

--- a/src/types.js
+++ b/src/types.js
@@ -211,15 +211,11 @@ export const escapeIdentifier = function escape(str) {
 }
 
 export const inferType = function inferType(x) {
-  return (
-    x instanceof Parameter ? x.type :
-    x instanceof Date ? 1184 :
-    x instanceof Uint8Array ? 17 :
-    (x === true || x === false) ? 16 :
-    typeof x === 'bigint' ? 20 :
-    Array.isArray(x) ? inferType(x[0]) :
-    0
-  )
+  return x instanceof Parameter
+    ? x.type
+    : Array.isArray(x)
+      ? inferType(x[0])
+      : 0
 }
 
 const escapeBackslash = /\\/g

--- a/tests/index.js
+++ b/tests/index.js
@@ -89,16 +89,16 @@ t('String', async() =>
 )
 
 t('Boolean false', async() =>
-  [false, (await sql`select ${ false } as x`)[0].x]
+  [false, (await sql`select ${ false }::bool as x`)[0].x]
 )
 
 t('Boolean true', async() =>
-  [true, (await sql`select ${ true } as x`)[0].x]
+  [true, (await sql`select ${ true }::bool as x`)[0].x]
 )
 
 t('Date', async() => {
   const now = new Date()
-  return [0, now - (await sql`select ${ now } as x`)[0].x]
+  return [0, now - (await sql`select ${ now }::timestamptz as x`)[0].x]
 })
 
 t('Json', async() => {
@@ -134,7 +134,8 @@ t('Array of String', async() =>
 
 t('Array of Date', async() => {
   const now = new Date()
-  return [now.getTime(), (await sql`select ${ sql.array([now, now, now]) } as x`)[0].x[2].getTime()]
+      , iso = now.toISOString()
+  return [now.getTime(), (await sql`select ${ sql.array([iso, iso, iso]) }::timestamptz[] as x`)[0].x[2].getTime()]
 })
 
 t('Nested array n2', async() =>
@@ -1034,10 +1035,7 @@ t('Multiple queries', async() => {
 })
 
 t('Multiple statements', async() =>
-  [2, await sql.unsafe(`
-    select 1 as x;
-    select 2 as a;
-  `).then(([, [x]]) => x.a)]
+  [2, await sql.unsafe(`select 1 as x;select 2 as a`).then(([, [x]]) => x.a)]
 )
 
 t('throws correct error when authentication fails', async() => {
@@ -1188,7 +1186,7 @@ t('Multiple Cursors', { timeout: 2 }, async() => {
 
 t('Cursor as async iterator', async() => {
   const order = []
-  for await (const [x] of sql`select generate_series(1,2) as x;`.cursor()) {
+  for await (const [x] of sql`select generate_series(1,2) as x`.cursor()) {
     order.push(x.x + 'a')
     await delay(10)
     order.push(x.x + 'b')
@@ -1199,7 +1197,7 @@ t('Cursor as async iterator', async() => {
 
 t('Cursor as async iterator with break', async() => {
   const order = []
-  for await (const xs of sql`select generate_series(1,2) as x;`.cursor()) {
+  for await (const xs of sql`select generate_series(1,2) as x`.cursor()) {
     order.push(xs[0].x + 'a')
     await delay(10)
     order.push(xs[0].x + 'b')
@@ -1519,7 +1517,7 @@ t('Recreate prepared statements on transformAssignedExpr error', { timeout: 1 },
 
 t('Throws correct error when retrying in transactions', async() => {
   await sql`create table test(x int)`
-  const error = await sql.begin(sql => sql`insert into test (x) values (${ false })`).catch(e => e)
+  const error = await sql.begin(sql => sql`insert into test (x) values (${ false }::bool)`).catch(e => e)
   return [
     error.code,
     '42804',


### PR DESCRIPTION
In v3 we rely on the PostgreSQL ParameterDescription message to decide on input types, but there is still some cases were we rely on types inferred from the js types first (https://github.com/porsager/postgres/blob/218a7d4f37dcbf76d01081413a386c00544ab63e/src/types.js#L213-L223). This [causes problems](https://github.com/porsager/postgres/issues/386) when trying to use some of these JS types as raw values for eg. `json` PostgreSQL types (and others). Because of the order of the protocol messages we are not able to give "hints" about types so it could be better to remove the "convenience" of implicitly inferring types from the js objects and instead require the users to write explicit casts in sql - eg `::type or cast(...)`. 

I'm still not certain this is the best way forward, and if someone sees an alternative solution that encompasses both scenarios - i am all ears.

For now, this PR can act as a test ground and discussion for the changed behaviour.