### PR TITLE
Minor typescript organization

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,7 @@ import { Readable, Writable } from 'node:stream'
  * @param options Connection options - default to the same as psql
  * @returns An utility function to make queries to the server
  */
-declare function postgres<T extends PostgresTypeList = {}>(options?: postgres.Options<T>): postgres.Sql<{ [type in keyof T]: T[type] extends {
+declare function postgres<T extends Record<string, postgres.PostgresType> = {}>(options?: postgres.Options<T>): postgres.Sql<Record<string, postgres.PostgresType> extends T ? {} : { [type in keyof T]: T[type] extends {
   serialize: (value: infer R) => any,
   parse: (raw: any) => infer R
 } ? R : never }>
@@ -15,7 +15,7 @@ declare function postgres<T extends PostgresTypeList = {}>(options?: postgres.Op
  * @param options Connection options - default to the same as psql
  * @returns An utility function to make queries to the server
  */
-declare function postgres<T extends PostgresTypeList = {}>(url: string, options?: postgres.Options<T>): postgres.Sql<{ [type in keyof T]: T[type] extends {
+declare function postgres<T extends Record<string, postgres.PostgresType> = {}>(url: string, options?: postgres.Options<T>): postgres.Sql<Record<string, postgres.PostgresType> extends T ? {} : { [type in keyof T]: T[type] extends {
   serialize: (value: infer R) => any,
   parse: (raw: any) => infer R
 } ? R : never }>
@@ -23,7 +23,7 @@ declare function postgres<T extends PostgresTypeList = {}>(url: string, options?
 /**
  * Connection options of Postgres.
  */
-interface BaseOptions<T extends PostgresTypeList> {
+interface BaseOptions<T extends Record<string, postgres.PostgresType>> {
   /** Postgres ip address[s] or domain name[s] */
   host: string | string[];
   /** Postgres server[s] port[s] */
@@ -126,7 +126,6 @@ interface BaseOptions<T extends PostgresTypeList> {
   keep_alive: number | null;
 }
 
-interface PostgresTypeList extends Record<string, postgres.PostgresType> {}
 
 declare const PRIVATE: unique symbol;
 
@@ -277,7 +276,7 @@ declare namespace postgres {
     [name: string]: string;
   }
 
-  interface Options<T extends PostgresTypeList> extends Partial<BaseOptions<T>> {
+  interface Options<T extends Record<string, postgres.PostgresType>> extends Partial<BaseOptions<T>> {
     /** @inheritdoc */
     host?: string;
     /** @inheritdoc */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,7 @@ import { Readable, Writable } from 'node:stream'
  * @param options Connection options - default to the same as psql
  * @returns An utility function to make queries to the server
  */
-declare function postgres<T extends PostgresTypeList>(options?: postgres.Options<T>): postgres.Sql<PostgresTypeList extends T ? {} : { [type in keyof T]: T[type] extends {
+declare function postgres<T extends PostgresTypeList = {}>(options?: postgres.Options<T>): postgres.Sql<{ [type in keyof T]: T[type] extends {
   serialize: (value: infer R) => any,
   parse: (raw: any) => infer R
 } ? R : never }>
@@ -15,7 +15,7 @@ declare function postgres<T extends PostgresTypeList>(options?: postgres.Options
  * @param options Connection options - default to the same as psql
  * @returns An utility function to make queries to the server
  */
-declare function postgres<T extends PostgresTypeList>(url: string, options?: postgres.Options<T>): postgres.Sql<PostgresTypeList extends T ? {} : { [type in keyof T]: T[type] extends {
+declare function postgres<T extends PostgresTypeList = {}>(url: string, options?: postgres.Options<T>): postgres.Sql<{ [type in keyof T]: T[type] extends {
   serialize: (value: infer R) => any,
   parse: (raw: any) => infer R
 } ? R : never }>
@@ -126,9 +126,7 @@ interface BaseOptions<T extends PostgresTypeList> {
   keep_alive: number | null;
 }
 
-interface PostgresTypeList {
-  [name: string]: postgres.PostgresType;
-}
+interface PostgresTypeList extends Record<string, postgres.PostgresType> {}
 
 declare const PRIVATE: unique symbol;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -130,10 +130,6 @@ interface PostgresTypeList {
   [name: string]: postgres.PostgresType;
 }
 
-interface JSToPostgresTypeMap {
-  [name: string]: unknown;
-}
-
 declare const PRIVATE: unique symbol;
 
 declare class NotAPromise {
@@ -315,7 +311,7 @@ declare namespace postgres {
     timeout?: Options<T>['idle_timeout'];
   }
 
-  interface ParsedOptions<T extends JSToPostgresTypeMap> extends BaseOptions<{ [name in keyof T]: PostgresType<T[name]> }> {
+  interface ParsedOptions<T extends Record<string, unknown> = {}> extends BaseOptions<{ [name in keyof T]: PostgresType<T[name]> }> {
     /** @inheritdoc */
     host: string[];
     /** @inheritdoc */
@@ -480,7 +476,7 @@ declare namespace postgres {
     | boolean
     | Date // serialized as `string`
     | readonly JSONValue[]
-    | { toJSON(): any } // `toJSON` called by `JSON.stringify`; not typing the return type, typings is strict enough anyway
+    | { toJSON(): any } // `toJSON` called by `JSON.stringify`; not typing the return type, types definition is strict enough anyway
     | {
       readonly [prop: string | number]:
       | undefined
@@ -583,7 +579,7 @@ declare namespace postgres {
     rest: U;
   }
 
-  interface Sql<TTypes extends JSToPostgresTypeMap> {
+  interface Sql<TTypes extends Record<string, unknown> = {}> {
     /**
      * Query helper
      * @param first Define how the helper behave
@@ -638,7 +634,7 @@ declare namespace postgres {
     prepare?: boolean;
   }
 
-  interface TransactionSql<TTypes extends JSToPostgresTypeMap> extends Sql<TTypes> {
+  interface TransactionSql<TTypes extends Record<string, unknown> = {}> extends Sql<TTypes> {
     savepoint<T>(cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
     savepoint<T>(name: string, cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,7 @@ import { Readable, Writable } from 'node:stream'
  * @param options Connection options - default to the same as psql
  * @returns An utility function to make queries to the server
  */
-declare function postgres<T extends Record<string, postgres.PostgresType> = {}>(options?: postgres.Options<T>): postgres.Sql<Record<string, postgres.PostgresType> extends T ? {} : { [type in keyof T]: T[type] extends {
+declare function postgres<T extends Record<string, postgres.PostgresType> = {}>(options?: postgres.Options<T> | undefined): postgres.Sql<Record<string, postgres.PostgresType> extends T ? {} : { [type in keyof T]: T[type] extends {
   serialize: (value: infer R) => any,
   parse: (raw: any) => infer R
 } ? R : never }>
@@ -15,7 +15,7 @@ declare function postgres<T extends Record<string, postgres.PostgresType> = {}>(
  * @param options Connection options - default to the same as psql
  * @returns An utility function to make queries to the server
  */
-declare function postgres<T extends Record<string, postgres.PostgresType> = {}>(url: string, options?: postgres.Options<T>): postgres.Sql<Record<string, postgres.PostgresType> extends T ? {} : { [type in keyof T]: T[type] extends {
+declare function postgres<T extends Record<string, postgres.PostgresType> = {}>(url: string, options?: postgres.Options<T> | undefined): postgres.Sql<Record<string, postgres.PostgresType> extends T ? {} : { [type in keyof T]: T[type] extends {
   serialize: (value: infer R) => any,
   parse: (raw: any) => infer R
 } ? R : never }>


### PR DESCRIPTION
* toJSON() of JSONValue returns JSONValue type
* TTypes defaults to JSToPostgresTypMap
* JSToPostgresTypeMap is in postgres namespace

The JSONValue type already includes recursive type references, so we may as well
guarantee that JSON.stringify() will get a JSONValue back.

Having to always include {} when referencing Sql<{}> is annoying.

This exposes the type parameter of the Sql interface for extension by other libraries that would like to extend it.