### PR TITLE
feat: use record instead of object for tagged template

### DIFF
--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -600,7 +600,7 @@ declare namespace postgres {
      * @param parameters Interpoled values of the template string
      * @returns A promise resolving to the result of your query
      */
-    <T extends readonly (object | undefined)[] = Row[]>(template: TemplateStringsArray, ...parameters: readonly (SerializableParameter<TTypes[keyof TTypes]> | PendingQuery<any>)[]): PendingQuery<AsRowList<T>>;
+    <T extends readonly (Record<string, any> | undefined)[] = Row[]>(template: TemplateStringsArray, ...parameters: readonly (SerializableParameter<TTypes[keyof TTypes]> | PendingQuery<any>)[]): PendingQuery<AsRowList<T>>;
 
     CLOSE: {};
     END: this['CLOSE'];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -598,7 +598,7 @@ declare namespace postgres {
      * @param parameters Interpoled values of the template string
      * @returns A promise resolving to the result of your query
      */
-    <T extends readonly (object | undefined)[] = Row[]>(template: TemplateStringsArray, ...parameters: readonly (SerializableParameter<TTypes[keyof TTypes]> | PendingQuery<any>)[]): PendingQuery<T>;
+    <T extends readonly (Record<string, any> | undefined)[] = Row[]>(template: TemplateStringsArray, ...parameters: readonly (SerializableParameter<TTypes[keyof TTypes]> | PendingQuery<any>)[]): PendingQuery<T>;
 
     CLOSE: {};
     END: this['CLOSE'];


### PR DESCRIPTION
The `object` type is pretty useless using `Record<string, any>` would fix multiple typing issues including [this](https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgEoHsDuyDeAoZZAbQXQBsBXAWxAC5kBnMKUAcwF164QBPAbjwBfPHhgUQCMMHQhkAZQCOZAIwAeACrIIAD0ggAJg2RQIcfTLI9kACnQAjAFYRJyAD7Jx+iDFAR9ASiJ2ZABeNCwggD5rSCoABzI4SHp1CHjEyDlmNgYAQSgoOB5-XAJjCDAKKFkQCjIyZDgjcQBrECxZJuR1IREdOPQoMGQERIYjSCYNOQQACzS4UPDMSNLCADc4KGUlxRVpuYWogAN9TDhj3rx+weHRpomIJgAmA-mqRbDuHlX8Da3nrslGp1DN3nATmcLlcxBIpDJ5EpXpodHpDOUzBYrNZUM5BvpVEwWCBWAAaRq8VbuTzeXwBIJLDCYKIxNIJJIQFJsjIQLLE1h5ApFEp-cqVarIWr1RrNEBtDoy7pXG5DEZjR5MADMbwWjKwvzKm22QLIyLBR3YkVO50uwmu2gGqvu42QkzAABYdR8lt8Df8oICwnszYcPpCbUIgA) one.