### PR TITLE
Add typescript support for "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "src/index.js",
   "main": "cjs/src/index.js",
   "exports": {
+    "types": "./types/index.d.ts",
     "import": "./src/index.js",
     "default": "./cjs/src/index.js"
   },


### PR DESCRIPTION
Allows typescript to properly resolve the types for this package when using the new Node.js’ ECMAScript Module Support

https://www.typescriptlang.org/tsconfig#moduleResolution