### PR TITLE
Improve typing - Generic type should accept an object instead of an object[]

### DIFF
--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -598,7 +598,7 @@ declare namespace postgres {
      * @param parameters Interpoled values of the template string
      * @returns A promise resolving to the result of your query
      */
-    <T extends readonly (object | undefined)[] = Row[]>(template: TemplateStringsArray, ...parameters: readonly (SerializableParameter<TTypes[keyof TTypes]> | PendingQuery<any>)[]): PendingQuery<AsRowList<T>>;
+    <T extends (object | undefined) = Row>(template: TemplateStringsArray, ...parameters: readonly (SerializableParameter<TTypes[keyof TTypes]> | PendingQuery<any>)[]): PendingQuery<AsRowList<T[]>>;
 
     CLOSE: {};
     END: this['CLOSE'];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -596,7 +596,7 @@ declare namespace postgres {
      * @param parameters Interpoled values of the template string
      * @returns A promise resolving to the result of your query
      */
-    <T extends readonly (object | undefined)[] = Row[]>(template: TemplateStringsArray, ...parameters: readonly (SerializableParameter<TTypes[keyof TTypes]> | PendingQuery<any>)[]): PendingQuery<T>;
+    <T extends (object | undefined) = Row>(template: TemplateStringsArray, ...parameters: readonly (SerializableParameter<TTypes[keyof TTypes]> | PendingQuery<any>)[]): PendingQuery<T[]>;
 
     CLOSE: {};
     END: this['CLOSE'];


### PR DESCRIPTION
Currently, in order to type a query, we need to pass it as generic as an array:

```ts
const q = await sql<{ text_col: string }[]>`select text_col from table_name`;
```

While it doesn't introduce any bugs, it's redundant to manually type it as an array (`type[]`) since it will always return an array.

I maintain a library ([SafeQL](https://github.com/ts-safeql/safeql)) that generates types based on queries (which uses this library, thanks to `.describe()`). While writing compatibility guides for each SQL library, I found out that this is the only library that requires adding `[]` at the end of the type.

Since it's a **breaking change**, I will fully understand if you would prefer not to merge it.

Although, there's a possibility to both support singles and arrays while maintaining backward compatibility, but it over complexes the type ([see demo](https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgEoHsDuyDeAoZQ5AbQXQBsBXAWxAC5kBnMKUAcwF0G4QBPAbjwBfPHhiUQCMMHQgmAR3IAeAkQAqyCAA9IIACaNkUCHD2zyvZAAp0AIwBWEKcgA+yCXogxQEPQEpiDldrO0dnNw8vH39kAF40LEC8AD4rSGoAB3I4SAY1CEzsyABlFnZGAEEoKDhePzzNHQh9Q1QTMxALKpreJQkAaxAsEGTkAH5kDTzA3FVCYzBKKDkcIWQ4Qx4BYVEyEGZkMABGOIVlHGRgPQYQGltoZCFkgANGCHInMEu9ZAAxVAA8gBZQ5wWwfAD6IDg1Agz0ERERyAA9MjkAA9MaiJFEPB7A5gABMp0YiiUFyuNzuDyEgRebw+ziuf0BILAYMh0NhzzmSNRGKxQA)):

```ts
<T extends readonly (object | undefined)[] | (object | undefined) = Row>(template: TemplateStringsArray, ...parameters: readonly (SerializableParameter<TTypes[keyof TTypes]> | PendingQuery<unknown>)[]): PendingQuery<T extends ReadonlyArray<any> ? T : T[]>;
```

Note the new T:

```diff
- T extends readonly (object | undefined)[] = Row[]
+ T extends readonly (object | undefined)[] | (object | undefined) = Row[]
```

and the new return type:

```diff
- PendingQuery<T[]>;
+ PendingQuery<T extends ReadonlyArray<unknown> ? T : T[]>;
```

Results in:

![image](https://user-images.githubusercontent.com/10504365/190347778-5c85a24e-0129-4940-bc04-7c4340c021c3.png)


On another note - There's a drift between the declaration types of nodejs and deno. I'm not sure if this is intentional.