### PR TITLE
Fix json serialization

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -16,7 +16,7 @@ export const types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: x => JSON.stringify(x),
+    serialize: x => x,
     parse: x => JSON.parse(x)
   },
   boolean: {


### PR DESCRIPTION
Hi!
I'm using `postgres@3.2.4` and having Postgres in version 13.8. When inserting into columns with `json` type I've found out that these values are stored as strings in Postgres. Additionally, when selecting these rows, strings were returned. I found out that it can be fixed by removing json serialization. Unfortunately, I don't have much experience in this lib, so I'm not sure whether the fix is fine. Let me know if I need to update some tests too.
Thanks and double thanks for this lib!