### PR TITLE
Fix connection uri encoding (Issue #399)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -486,8 +486,18 @@ function parseUrl(url) {
   host = host.slice(host.indexOf('://') + 3).split(/[?/]/)[0]
   host = decodeURIComponent(host.slice(host.indexOf('@') + 1))
 
+  const urlObj = new URL(url.replace(host, host.split(',')[0]))
+
   return {
-    url: new URL(url.replace(host, host.split(',')[0])),
+    url: {
+      username: decodeURIComponent(urlObj.username),
+      password: decodeURIComponent(urlObj.password),
+      host: urlObj.host,
+      hostname: urlObj.hostname,
+      port: urlObj.port,
+      pathname: urlObj.pathname,
+      searchParams: urlObj.searchParams
+    },
     multihost: host.indexOf(',') > -1 && host
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -351,6 +351,11 @@ t('Connect using uri', async() =>
   })]
 )
 
+t('Options from uri with special characters in user and pass', async() => {
+  const opt = postgres({ user: 'öla', pass: 'pass^word' }).options
+  return [[opt.user, opt.pass].toString(), 'öla,pass^word']
+})
+
 t('Fail with proper error on no host', async() =>
   ['ECONNREFUSED', (await new Promise((resolve, reject) => {
     const sql = postgres('postgres://localhost:33333/' + options.db, {


### PR DESCRIPTION
Use decodeURIComponent to decode the user and pass from connection uri.
So that connections to pg work when using uri strings with special characters in user or pass.

Fixes #399