### PR TITLE
Allow for incomplete custom types

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -203,8 +203,10 @@ export const mergeUserTypes = function(types) {
 function typeHandlers(types) {
   return Object.keys(types).reduce((acc, k) => {
     types[k].from && [].concat(types[k].from).forEach(x => acc.parsers[x] = types[k].parse)
-    acc.serializers[types[k].to] = types[k].serialize
-    types[k].from && [].concat(types[k].from).forEach(x => acc.serializers[x] = types[k].serialize)
+    if (types[k].serialize) {
+      acc.serializers[types[k].to] = types[k].serialize
+      types[k].from && [].concat(types[k].from).forEach(x => acc.serializers[x] = types[k].serialize)
+    }
     return acc
   }, { parsers: {}, serializers: {} })
 }


### PR DESCRIPTION
Specifically, I'd like to be able to get away with a type definition consisting in just the `to` property, like this:
`
    int4: {
      to: 23
    }
`
That's because I merely want to use a name for a PostgreSQL type OID and the usual conversions are already defined in this file. As a fallback, the default serialization in _src/connection.js_ at line _912_ is just fine.