### PR TITLE
Fix null in nested json array transform error

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -39,6 +39,10 @@ export const types = {
   }
 }
 
+const allowList = {
+  object: typeof Object
+}
+
 class NotTagged { then() { notTagged() } catch() { notTagged() } finally() { notTagged() }}
 
 export class Identifier extends NotTagged {
@@ -329,7 +333,7 @@ export const fromKebab = x => x.replace(/-/g, '_')
 
 function createJsonTransform(fn) {
   return function jsonTransform(x, column) {
-    return column.type === 114 || column.type === 3802
+    return (x && typeof x in allowList) && (column.type === 114 || column.type === 3802)
       ? Array.isArray(x)
         ? x.map(x => jsonTransform(x, column))
         : Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: v }), {})

--- a/src/types.js
+++ b/src/types.js
@@ -39,10 +39,6 @@ export const types = {
   }
 }
 
-const allowList = {
-  object: typeof Object
-}
-
 class NotTagged { then() { notTagged() } catch() { notTagged() } finally() { notTagged() }}
 
 export class Identifier extends NotTagged {
@@ -333,7 +329,7 @@ export const fromKebab = x => x.replace(/-/g, '_')
 
 function createJsonTransform(fn) {
   return function jsonTransform(x, column) {
-    return (x && typeof x in allowList) && (column.type === 114 || column.type === 3802)
+    return typeof x === 'object' && x !== null && (column.type === 114 || column.type === 3802)
       ? Array.isArray(x)
         ? x.map(x => jsonTransform(x, column))
         : Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: v }), {})

--- a/tests/index.js
+++ b/tests/index.js
@@ -622,7 +622,7 @@ t('Bypass transform for json primitive', async () => {
   )[0]
 
   return [
-    JSON.stringify({ a: null, b: false, c: { 0: 'a' }, d: {} }),
+    JSON.stringify({ a: null, b: false, c: 'a', d: 1 }),
     JSON.stringify(x),
   ]
 })
@@ -638,7 +638,7 @@ t('Bypass transform for jsonb primitive', async () => {
   )[0]
 
   return [
-    JSON.stringify({ a: null, b: false, c: { 0: 'a' }, d: {} }),
+    JSON.stringify({ a: null, b: false, c: 'a', d: 1 }),
     JSON.stringify(x),
   ]
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -615,32 +615,33 @@ t('Bypass transform for json primitive', async () => {
   const sql = postgres({
     ...options,
     transform: postgres.camel,
-  });
+  })
 
   const x = (
     await sql`select 'null'::json as a, 'false'::json as b, '"a"'::json as c, '1'::json as d`
-  )[0];
+  )[0]
 
   return [
     JSON.stringify({ a: null, b: false, c: { 0: 'a' }, d: {} }),
     JSON.stringify(x),
-  ];
-});
+  ]
+})
 
 t('Bypass transform for jsonb primitive', async () => {
   const sql = postgres({
     ...options,
     transform: postgres.camel,
-  });
+  })
+
   const x = (
     await sql`select 'null'::jsonb as a, 'false'::jsonb as b, '"a"'::jsonb as c, '1'::jsonb as d`
-  )[0];
+  )[0]
 
   return [
     JSON.stringify({ a: null, b: false, c: { 0: 'a' }, d: {} }),
     JSON.stringify(x),
-  ];
-});
+  ]
+})
 
 t('unsafe', async() => {
   await sql`create table test (x int)`

--- a/tests/index.js
+++ b/tests/index.js
@@ -611,6 +611,14 @@ t('Transform nested json in arrays', async() => {
   return ['aBcD', (await sql`select '[{"a_b":1},{"c_d":2}]'::jsonb as x`)[0].x.map(Object.keys).join('')]
 })
 
+t('Transform null json in arrays', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  return [null, (await sql`select '[{"a_b":null},{"c_d":null}]'::jsonb as x`)[0].x.map(Object.keys).join('')]
+})
+
 t('unsafe', async() => {
   await sql`create table test (x int)`
   return [1, (await sql.unsafe('insert into test values ($1) returning *', [1]))[0].x, await sql`drop table test`]

--- a/tests/index.js
+++ b/tests/index.js
@@ -611,13 +611,36 @@ t('Transform nested json in arrays', async() => {
   return ['aBcD', (await sql`select '[{"a_b":1},{"c_d":2}]'::jsonb as x`)[0].x.map(Object.keys).join('')]
 })
 
-t('Bypass transform for json primitive', async() => {
+t('Bypass transform for json primitive', async () => {
   const sql = postgres({
     ...options,
-    transform: postgres.camel
-  })
-  return [null, false, 'a', '1', (await sql`select '${ null }'::jsonb as x, '${ false }'::jsonb as x, '${ "a" }'::json as x, '${ 1 }'::json as x`)[0].x]
-})
+    transform: postgres.camel,
+  });
+
+  const x = (
+    await sql`select 'null'::json as a, 'false'::json as b, '"a"'::json as c, '1'::json as d`
+  )[0];
+
+  return [
+    JSON.stringify({ a: null, b: false, c: { 0: 'a' }, d: {} }),
+    JSON.stringify(x),
+  ];
+});
+
+t('Bypass transform for jsonb primitive', async () => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel,
+  });
+  const x = (
+    await sql`select 'null'::jsonb as a, 'false'::jsonb as b, '"a"'::jsonb as c, '1'::jsonb as d`
+  )[0];
+
+  return [
+    JSON.stringify({ a: null, b: false, c: { 0: 'a' }, d: {} }),
+    JSON.stringify(x),
+  ];
+});
 
 t('unsafe', async() => {
   await sql`create table test (x int)`

--- a/tests/index.js
+++ b/tests/index.js
@@ -611,12 +611,12 @@ t('Transform nested json in arrays', async() => {
   return ['aBcD', (await sql`select '[{"a_b":1},{"c_d":2}]'::jsonb as x`)[0].x.map(Object.keys).join('')]
 })
 
-t('Transform null json in arrays', async() => {
+t('Bypass transform for json primitive', async() => {
   const sql = postgres({
     ...options,
     transform: postgres.camel
   })
-  return [null, (await sql`select '[{"a_b":null},{"c_d":null}]'::jsonb as x`)[0].x.map(Object.keys).join('')]
+  return [null, false, 'a', '1', (await sql`select '${ null }'::jsonb as x, '${ false }'::jsonb as x, '${ "a" }'::json as x, '${ 1 }'::json as x`)[0].x]
 })
 
 t('unsafe', async() => {


### PR DESCRIPTION
Transforming a json with `null` value throws the below error
```
 Uncaught TypeError: Cannot convert undefined or null to object
```
For example, the object below throws an error when it hits the  `Object.entries(x)` part of the transform function
```js
obj = {
id: 1,
name: 'Victor,
age: null
}
```
<img width="860" alt="Screenshot 2022-10-19 at 10 14 15" src="https://user-images.githubusercontent.com/74430629/196639198-5168f7e8-e3ea-41d4-8070-a3219dc0d656.png">

I think checking for `x` before passing it to the `Object.entries(x)` would prevent this error. So we only pass `x` to be transformed when we are sure that it is `object`,  `array`,  not `null` and `json`. 
The diff below would be the suggested fix
```diff
- column.type === 114 || column.type === 3802
+ (x && typeof x in allowList) && (column.type === 114 || column.type === 3802)
```
