### PR TITLE
Fix transform function logic for deeply nested jsonb

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -332,7 +332,10 @@ function createJsonTransform(fn) {
     return typeof x === 'object' && x !== null && (column.type === 114 || column.type === 3802)
       ? Array.isArray(x)
         ? x.map(x => jsonTransform(x, column))
-        : Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: v }), {})
+        : Object.entries(x).reduce((acc, [k, v]) => {
+          const transformedKey = fn(k)
+          return Object.assign(acc, { [transformedKey]: jsonTransform(v, column) })
+        }, {})
       : x
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -631,6 +631,26 @@ t('Transform deeply nested json object in arrays', async() => {
       .join('_')]
 })
 
+t('Transform deeply nested json array in arrays', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  return ['childArray_deeplyNestedArray_grandchildArray', (await sql`select '[{"nested_array": [{"child_array": 2, "deeply_nested_array": [{"grandchild_array":3}]}]}]'::jsonb AS x`)[0].x
+      .map((x) => {
+        let result;
+        for (const key in x) {
+          const result1 = Object.keys(x[key][0]);
+          const result2 = Object.keys(x[key][0].deeplyNestedArray[0]);
+
+          result = [...result1, ...result2];
+        }
+
+        return result;
+      })[0]
+      .join('_')]
+})
+
 t('Bypass transform for json primitive', async() => {
   const sql = postgres({
     ...options,

--- a/tests/index.js
+++ b/tests/index.js
@@ -611,6 +611,26 @@ t('Transform nested json in arrays', async() => {
   return ['aBcD', (await sql`select '[{"a_b":1},{"c_d":2}]'::jsonb as x`)[0].x.map(Object.keys).join('')]
 })
 
+t('Transform deeply nested json object in arrays', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  return ['childObj_deeplyNestedObj_grandchildObj', (await sql`select '[{"nested_obj": {"child_obj": 2, "deeply_nested_obj": {"grandchild_obj": 3}}}]'::jsonb as x`)[0].x
+      .map((x) => {
+        let result;
+        for (const key in x) {
+          const result1 = Object.keys(x[key]);
+          const result2 = Object.keys(x[key].deeplyNestedObj);
+
+          result = [...result1, ...result2];
+        }
+
+        return result;
+      })[0]
+      .join('_')]
+})
+
 t('Bypass transform for json primitive', async() => {
   const sql = postgres({
     ...options,

--- a/tests/index.js
+++ b/tests/index.js
@@ -611,6 +611,46 @@ t('Transform nested json in arrays', async() => {
   return ['aBcD', (await sql`select '[{"a_b":1},{"c_d":2}]'::jsonb as x`)[0].x.map(Object.keys).join('')]
 })
 
+t('Transform deeply nested json object in arrays', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  return ['childObj_deeplyNestedObj_grandchildObj', (await sql`select '[{"nested_obj": {"child_obj": 2, "deeply_nested_obj": {"grandchild_obj": 3}}}]'::jsonb as x`)[0].x
+      .map((x) => {
+        let result;
+        for (const key in x) {
+          const result1 = Object.keys(x[key]);
+          const result2 = Object.keys(x[key].deeplyNestedObj);
+
+          result = [...result1, ...result2];
+        }
+
+        return result;
+      })[0]
+      .join('_')]
+})
+
+t('Transform deeply nested json array in arrays', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  return ['childArray_deeplyNestedArray_grandchildArray', (await sql`select '[{"nested_array": [{"child_array": 2, "deeply_nested_array": [{"grandchild_array":3}]}]}]'::jsonb AS x`)[0].x
+      .map((x) => {
+        let result;
+        for (const key in x) {
+          const result1 = Object.keys(x[key][0]);
+          const result2 = Object.keys(x[key][0].deeplyNestedArray[0]);
+
+          result = [...result1, ...result2];
+        }
+
+        return result;
+      })[0]
+      .join('_')]
+})
+
 t('Bypass transform for json primitive', async() => {
   const sql = postgres({
     ...options,

--- a/tests/index.js
+++ b/tests/index.js
@@ -611,46 +611,6 @@ t('Transform nested json in arrays', async() => {
   return ['aBcD', (await sql`select '[{"a_b":1},{"c_d":2}]'::jsonb as x`)[0].x.map(Object.keys).join('')]
 })
 
-t('Transform deeply nested json object in arrays', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  return ['childObj_deeplyNestedObj_grandchildObj', (await sql`select '[{"nested_obj": {"child_obj": 2, "deeply_nested_obj": {"grandchild_obj": 3}}}]'::jsonb as x`)[0].x
-      .map((x) => {
-        let result;
-        for (const key in x) {
-          const result1 = Object.keys(x[key]);
-          const result2 = Object.keys(x[key].deeplyNestedObj);
-
-          result = [...result1, ...result2];
-        }
-
-        return result;
-      })[0]
-      .join('_')]
-})
-
-t('Transform deeply nested json array in arrays', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  return ['childArray_deeplyNestedArray_grandchildArray', (await sql`select '[{"nested_array": [{"child_array": 2, "deeply_nested_array": [{"grandchild_array":3}]}]}]'::jsonb AS x`)[0].x
-      .map((x) => {
-        let result;
-        for (const key in x) {
-          const result1 = Object.keys(x[key][0]);
-          const result2 = Object.keys(x[key][0].deeplyNestedArray[0]);
-
-          result = [...result1, ...result2];
-        }
-
-        return result;
-      })[0]
-      .join('_')]
-})
-
 t('Bypass transform for json primitive', async() => {
   const sql = postgres({
     ...options,


### PR DESCRIPTION
The `createJsonTransform()` function is not transforming deeply nested objects and arrays in jsonb

```js
function createJsonTransform(fn) {
  return function jsonTransform(x, column) {
    return typeof x === 'object' && x !== null && (column.type === 114 || column.type === 3802)
      ? Array.isArray(x)
        ? x.map(x => jsonTransform(x, column))
        : Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: v }), {})
      : x
  }
}
```
## Problem
It wasn't transforming deeply nested arrays and objects because the `reduce()` method only iterate over the keys and values of the top-level object. It does not recursively transform the keys of any subsequent nested objects.

## Solution
`jsonTransform()` function needs to be called on the values of each key-value pair in the object so that it can keep iterating and transforming them regardless of how deeply nested they are.
Example:
```js
function createJsonTransform(fn) {
  return function jsonTransform(x, column) {
    return typeof x === 'object' && x !== null && (column.type === 114 || column.type === 3802)
      ? Array.isArray(x)
        // Recursively transform array elements
        ? x.map(x => jsonTransform(x, column))
        // Recursively transform object keys and values
        : Object.entries(x).reduce((acc, [k, v]) => {
          // Use fn() to transform the key
          const transformedKey = fn(k);
          return Object.assign(acc, { [transformedKey]: jsonTransform(v, column) });
        }, {})
      // Return non-object values as-is
      : x;
  };
}
```
