### PR TITLE
Fix writing host and port on connection timeouts

### DIFF
--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -339,6 +339,9 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       return socket.connect(options.path)
 
     socket.connect(port[hostIndex], host[hostIndex])
+    socket.host = host[hostIndex]
+    socket.port = port[hostIndex]
+
     hostIndex = (hostIndex + 1) % port.length
   }
 

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -1577,6 +1577,22 @@ t('connect_timeout throws proper error', async() => [
   })`select 1`.catch(e => e.code)
 ])
 
+t('connect_timeout error message includes host:port', { timeout: 20 }, async() => {
+  const connect_timeout = 0.2
+  const server = net.createServer()
+  server.listen()
+  const sql = postgres({ port: server.address().port, host: '127.0.0.1', connect_timeout })
+  const port = server.address().port
+  let err
+  await sql`select 1`.catch((e) => {
+    if (e.code !== 'CONNECT_TIMEOUT')
+      throw e
+    err = e.message
+  })
+  server.close()
+  return [["write CONNECT_TIMEOUT 127.0.0.1:", port].join(""), err]
+})
+
 t('requests works after single connect_timeout', async() => {
   let first = true
 

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -343,6 +343,9 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       return socket.connect(options.path)
 
     socket.connect(port[hostIndex], host[hostIndex])
+    socket.host = host[hostIndex]
+    socket.port = port[hostIndex]
+
     hostIndex = (hostIndex + 1) % port.length
   }
 

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -1579,6 +1579,22 @@ t('connect_timeout throws proper error', async() => [
   })`select 1`.catch(e => e.code)
 ])
 
+t('connect_timeout error message includes host:port', { timeout: 20 }, async() => {
+  const connect_timeout = 0.2
+  const server = net.createServer()
+  server.listen()
+  const sql = postgres({ port: server.address().port, host: '127.0.0.1', connect_timeout })
+  const port = server.address().port
+  let err
+  await sql`select 1`.catch((e) => {
+    if (e.code !== 'CONNECT_TIMEOUT')
+      throw e
+    err = e.message
+  })
+  server.close()
+  return [["write CONNECT_TIMEOUT 127.0.0.1:", port].join(""), err]
+})
+
 t('requests works after single connect_timeout', async() => {
   let first = true
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -339,6 +339,9 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       return socket.connect(options.path)
 
     socket.connect(port[hostIndex], host[hostIndex])
+    socket.host = host[hostIndex]
+    socket.port = port[hostIndex]
+
     hostIndex = (hostIndex + 1) % port.length
   }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -1577,6 +1577,22 @@ t('connect_timeout throws proper error', async() => [
   })`select 1`.catch(e => e.code)
 ])
 
+t('connect_timeout error message includes host:port', { timeout: 20 }, async() => {
+  const connect_timeout = 0.2
+  const server = net.createServer()
+  server.listen()
+  const sql = postgres({ port: server.address().port, host: '127.0.0.1', connect_timeout })
+  const port = server.address().port
+  let err
+  await sql`select 1`.catch((e) => {
+    if (e.code !== 'CONNECT_TIMEOUT')
+      throw e
+    err = e.message
+  })
+  server.close()
+  return [["write CONNECT_TIMEOUT 127.0.0.1:", port].join(""), err]
+})
+
 t('requests works after single connect_timeout', async() => {
   let first = true
 


### PR DESCRIPTION
Received a `write CONNECT_TIMEOUT undefined:undefined` when the configuration was correct, but something in the network was incorrectly configured.

The Deno polyfill already sets these options, but the Node.js socket doesn't expose them. Defaulting to the options object would also be an option here, but then we need to know which `options.host[idx]` is currently used.