### PR TITLE
pass servername to tls.connect

### DIFF
--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -256,6 +256,18 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     socket.destroy()
   }
 
+  function isIP(input) {
+    if (net.isIP) {
+      return net.isIP(host) !== 0
+    }
+    // fallback to our own implementation.
+    if (input.length === 0) {
+      return false
+    }
+    const firstLetter = input.charAt(0)
+    return firstLetter === ':' || !isNaN(firstLetter)
+  }
+
   async function secure() {
     write(SSLRequest)
     const canSSL = await new Promise(r => socket.once('data', x => r(x[0] === 83))) // S
@@ -273,7 +285,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       sslOptions.rejectUnauthorized = false
     }
 
-    if (!sslOptions.servername && net.isIP(host) === 0) {
+    if (!options.servername && !isIP(host)) {
       sslOptions.servername = host[0]
     }
 

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -256,18 +256,15 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     socket.destroy()
   }
 
-  function firstAddrIsIP(addressList) {
-    if (!Array.isArray(addressList)) {
-      return false
-    }
-    if (addressList.length === 0) {
-      return false
-    }
+  function firstAddrIsIP(address) {
     if (net.isIP) {
-      return net.isIP(addressList[0]) !== 0
+      return net.isIP(address) !== 0
+    }
+    if (address.length === 0) {
+      return false
     }
     // fallback to our own implementation.
-    const firstLetter = addressList[0].charAt(0)
+    const firstLetter = address.charAt(0)
     return firstLetter === ':' || !isNaN(firstLetter)
   }
 
@@ -288,7 +285,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       sslOptions.rejectUnauthorized = false
     }
 
-    if (!options.servername && !firstAddrIsIP(host)) {
+    if (!options.servername && !firstAddrIsIP(host[0])) {
       sslOptions.servername = host[0]
     }
 

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -256,15 +256,18 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     socket.destroy()
   }
 
-  function isIP(input) {
-    if (net.isIP) {
-      return net.isIP(host) !== 0
-    }
-    // fallback to our own implementation.
-    if (input.length === 0) {
+  function firstAddrIsIP(addressList) {
+    if (!Array.isArray(addressList)) {
       return false
     }
-    const firstLetter = input.charAt(0)
+    if (addressList.length === 0) {
+      return false
+    }
+    if (net.isIP) {
+      return net.isIP(addressList[0]) !== 0
+    }
+    // fallback to our own implementation.
+    const firstLetter = addressList[0].charAt(0)
     return firstLetter === ':' || !isNaN(firstLetter)
   }
 
@@ -285,7 +288,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       sslOptions.rejectUnauthorized = false
     }
 
-    if (!options.servername && !isIP(host)) {
+    if (!options.servername && !firstAddrIsIP(host)) {
       sslOptions.servername = host[0]
     }
 

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -271,8 +271,6 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       socket,
     }
 
-    console.log("chapson!!!")
-
     if (typeof ssl === 'object') {
       Object.assign(sslOptions, ssl)
     } else if (['require', 'allow', 'prefer'].includes(ssl)) {

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -260,15 +260,18 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     socket.destroy()
   }
 
-  function isIP(input) {
-    if (net.isIP) {
-      return net.isIP(host) !== 0
-    }
-    // fallback to our own implementation.
-    if (input.length === 0) {
+  function firstAddrIsIP(addressList) {
+    if (!Array.isArray(addressList)) {
       return false
     }
-    const firstLetter = input.charAt(0)
+    if (addressList.length === 0) {
+      return false
+    }
+    if (net.isIP) {
+      return net.isIP(addressList[0]) !== 0
+    }
+    // fallback to our own implementation.
+    const firstLetter = addressList[0].charAt(0)
     return firstLetter === ':' || !isNaN(firstLetter)
   }
 
@@ -289,8 +292,8 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       sslOptions.rejectUnauthorized = false
     }
 
-    if (!options.servername && !isIP(host)) {
-      options.servername = host
+    if (!options.servername && !firstAddrIsIP(host)) {
+      sslOptions.servername = host[0]
     }
 
     socket.removeAllListeners()

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -267,18 +267,24 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     if (!canSSL && ssl === 'prefer')
       return connected()
 
-    socket.removeAllListeners()
-    socket = tls.connect({
+    const sslOptions = {
       socket,
-      ...(ssl === 'require' || ssl === 'allow' || ssl === 'prefer'
-        ? { rejectUnauthorized: false }
-        : ssl === 'verify-full'
-          ? {}
-          : typeof ssl === 'object'
-            ? ssl
-            : {}
-      )
-    })
+    }
+
+    console.log("chapson!!!")
+
+    if (typeof ssl === 'object') {
+      Object.assign(sslOptions, ssl)
+    } else if (['require', 'allow', 'prefer'].includes(ssl)) {
+      sslOptions.rejectUnauthorized = false
+    }
+
+    if (!options.servername && net.isIP(host) === 0) {
+      options.servername = host
+    }
+
+    socket.removeAllListeners()
+    socket = tls.connect(sslOptions)
     socket.on('secureConnect', connected)
     socket.on('error', error)
     socket.on('close', closed)

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -260,18 +260,15 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     socket.destroy()
   }
 
-  function firstAddrIsIP(addressList) {
-    if (!Array.isArray(addressList)) {
-      return false
-    }
-    if (addressList.length === 0) {
-      return false
-    }
+  function firstAddrIsIP(address) {
     if (net.isIP) {
-      return net.isIP(addressList[0]) !== 0
+      return net.isIP(address) !== 0
+    }
+    if (address.length === 0) {
+      return false
     }
     // fallback to our own implementation.
-    const firstLetter = addressList[0].charAt(0)
+    const firstLetter = address.charAt(0)
     return firstLetter === ':' || !isNaN(firstLetter)
   }
 
@@ -292,7 +289,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       sslOptions.rejectUnauthorized = false
     }
 
-    if (!options.servername && !firstAddrIsIP(host)) {
+    if (!options.servername && !firstAddrIsIP(host[0])) {
       sslOptions.servername = host[0]
     }
 

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -260,6 +260,18 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     socket.destroy()
   }
 
+  function isIP(input) {
+    if (net.isIP) {
+      return net.isIP(host) !== 0
+    }
+    // fallback to our own implementation.
+    if (input.length === 0) {
+      return false
+    }
+    const firstLetter = input.charAt(0)
+    return firstLetter === ':' || !isNaN(firstLetter)
+  }
+
   async function secure() {
     write(SSLRequest)
     const canSSL = await new Promise(r => socket.once('data', x => r(x[0] === 83))) // S
@@ -277,7 +289,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       sslOptions.rejectUnauthorized = false
     }
 
-    if (!options.servername && net.isIP(host) === 0) {
+    if (!options.servername && !isIP(host)) {
       options.servername = host
     }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -256,6 +256,18 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     socket.destroy()
   }
 
+  function isIP(input) {
+    if (net.isIP) {
+      return net.isIP(host) !== 0
+    }
+    // fallback to our own implementation.
+    if (input.length === 0) {
+      return false
+    }
+    const firstLetter = input.charAt(0)
+    return firstLetter === ':' || !isNaN(firstLetter)
+  }
+
   async function secure() {
     write(SSLRequest)
     const canSSL = await new Promise(r => socket.once('data', x => r(x[0] === 83))) // S
@@ -273,7 +285,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       sslOptions.rejectUnauthorized = false
     }
 
-    if (!sslOptions.servername && net.isIP(host) === 0) {
+    if (!options.servername && !isIP(host)) {
       sslOptions.servername = host[0]
     }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -256,18 +256,15 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     socket.destroy()
   }
 
-  function firstAddrIsIP(addressList) {
-    if (!Array.isArray(addressList)) {
-      return false
-    }
-    if (addressList.length === 0) {
-      return false
-    }
+  function firstAddrIsIP(address) {
     if (net.isIP) {
-      return net.isIP(addressList[0]) !== 0
+      return net.isIP(address) !== 0
+    }
+    if (address.length === 0) {
+      return false
     }
     // fallback to our own implementation.
-    const firstLetter = addressList[0].charAt(0)
+    const firstLetter = address.charAt(0)
     return firstLetter === ':' || !isNaN(firstLetter)
   }
 
@@ -288,7 +285,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       sslOptions.rejectUnauthorized = false
     }
 
-    if (!options.servername && !firstAddrIsIP(host)) {
+    if (!options.servername && !firstAddrIsIP(host[0])) {
       sslOptions.servername = host[0]
     }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -256,15 +256,18 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     socket.destroy()
   }
 
-  function isIP(input) {
-    if (net.isIP) {
-      return net.isIP(host) !== 0
-    }
-    // fallback to our own implementation.
-    if (input.length === 0) {
+  function firstAddrIsIP(addressList) {
+    if (!Array.isArray(addressList)) {
       return false
     }
-    const firstLetter = input.charAt(0)
+    if (addressList.length === 0) {
+      return false
+    }
+    if (net.isIP) {
+      return net.isIP(addressList[0]) !== 0
+    }
+    // fallback to our own implementation.
+    const firstLetter = addressList[0].charAt(0)
     return firstLetter === ':' || !isNaN(firstLetter)
   }
 
@@ -285,7 +288,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       sslOptions.rejectUnauthorized = false
     }
 
-    if (!options.servername && !isIP(host)) {
+    if (!options.servername && !firstAddrIsIP(host)) {
       sslOptions.servername = host[0]
     }
 


### PR DESCRIPTION
This addresses the inability to connect using SNI to a TCP proxy hosting multiple Postgres instances behind itself. This is, for example, the case of https://neon.tech. With this patch, it is possible to establish a connection to the Neon compute-node by specifying `postgres('database_url', { ssl: true })` while connecting from Javascript. Without this patch, the `servername` is not passed.

See [nodejs docs](https://nodejs.org/docs/latest/api/tls.html#tls_tls_connect_options_callback) for details on `servername` option and SNI extension to TLS.