### PR TITLE
fix: unlisten channel names with period

### DIFF
--- a/cjs/src/index.js
+++ b/cjs/src/index.js
@@ -192,7 +192,9 @@ function Postgres(a, b) {
         return
 
       delete channels[name]
-      return sql`unlisten ${ sql(name) }`
+      return sql`unlisten ${
+        sql.unsafe('"' + name.replace(/"/g, '""') + '"')
+      }`
     }
   }
 

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -785,8 +785,10 @@ t('listen and notify with weird name', async() => {
   const sql = postgres(options)
   const channel = 'wat-;.ø.§'
   const result = await new Promise(async r => {
-    await sql.listen(channel, r)
+    const { unlisten } = await sql.listen(channel, r)
     sql.notify(channel, 'works')
+    await delay(50)
+    await unlisten()
   })
 
   return [

--- a/deno/src/index.js
+++ b/deno/src/index.js
@@ -193,7 +193,9 @@ function Postgres(a, b) {
         return
 
       delete channels[name]
-      return sql`unlisten ${ sql(name) }`
+      return sql`unlisten ${
+        sql.unsafe('"' + name.replace(/"/g, '""') + '"')
+      }`
     }
   }
 

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -787,8 +787,10 @@ t('listen and notify with weird name', async() => {
   const sql = postgres(options)
   const channel = 'wat-;.ø.§'
   const result = await new Promise(async r => {
-    await sql.listen(channel, r)
+    const { unlisten } = await sql.listen(channel, r)
     sql.notify(channel, 'works')
+    await delay(50)
+    await unlisten()
   })
 
   return [

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,9 @@ function Postgres(a, b) {
         return
 
       delete channels[name]
-      return sql`unlisten ${ sql(name) }`
+      return sql`unlisten ${
+        sql.unsafe('"' + name.replace(/"/g, '""') + '"')
+      }`
     }
   }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -785,8 +785,10 @@ t('listen and notify with weird name', async() => {
   const sql = postgres(options)
   const channel = 'wat-;.ø.§'
   const result = await new Promise(async r => {
-    await sql.listen(channel, r)
+    const { unlisten } = await sql.listen(channel, r)
     sql.notify(channel, 'works')
+    await delay(50)
+    await unlisten()
   })
 
   return [


### PR DESCRIPTION
Similar to porsager/postgres@a12108ab7916afa8bf0e451ee61cae47f63cf1af