### PR TITLE
readme: add correction in the "Multiple updates in one query" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ sql`
   update users set name = update_data.name, (age = update_data.age)::int
   from (values ${sql(users)}) as update_data (id, name, age)
   where users.id = (update_data.id)::int
-  returning users.id, users.sort_order
+  returning users.id, users.name, users.age
 `
 ```
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,10 @@ const users = [
 ]
 
 sql`
-  update users set name = update_data.name, age = update_data.age
+  update users set name = update_data.name, (age = update_data.age)::int
   from (values ${sql(users)}) as update_data (id, name, age)
-  where users.id = update_data.id
+  where users.id = (update_data.id)::int
+  returning users.id, users.sort_order
 `
 ```
 


### PR DESCRIPTION
In the "Multiple updates in one query" it seems it is necessary to do explicit type casting if the data type is not text (in both the SET and WHERE clauses). 

If not, I see one of these errors:

- `column "sort_order" is of type integer but expression is of type text`
- `operator does not exist: integer = text`

I also added the "returning" at the end to confirm that the data was updated.