### PR TITLE
Feat: add role options to transactions

### DIFF
--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -166,6 +166,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       build(q)
       return write(toBuffer(q))
         && !q.describeFirst
+        && !q.cursorFn
         && sent.length < max_pipeline
         && (!q.options.onexecute || q.options.onexecute(connection))
     } catch (error) {

--- a/cjs/src/index.js
+++ b/cjs/src/index.js
@@ -204,12 +204,16 @@ function Postgres(a, b) {
 
   async function begin(options, fn) {
     !fn && (fn = options, options = '')
+    if (typeof options === 'string') options = { beginOptions: options }
+    !options.beginOptions && (options.beginOptions = '')
+
     const queries = Queue()
     let savepoints = 0
       , connection
 
     try {
-      await sql.unsafe('begin ' + options.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
+      await sql.unsafe('begin ' + options.beginOptions.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
+      options.role && await sql`SET ROLE ${sql(options.role)};`
       return await scope(connection, fn)
     } catch (error) {
       throw error

--- a/cjs/tests/bootstrap.js
+++ b/cjs/tests/bootstrap.js
@@ -8,6 +8,8 @@ exec('psql', ['-c', 'create user postgres_js_test_md5 with password \'postgres_j
 exec('psql', ['-c', 'alter system set password_encryption=\'scram-sha-256\''])
 exec('psql', ['-c', 'select pg_reload_conf()'])
 exec('psql', ['-c', 'create user postgres_js_test_scram with password \'postgres_js_test_scram\''])
+exec('psql', ['-c', 'create role postgres_js_test_set_role'])
+exec('psql', ['-c', 'grant postgres_js_test_set_role TO postgres_js_test'])
 
 exec('dropdb', ['postgres_js_test'])
 exec('createdb', ['postgres_js_test'])
@@ -15,7 +17,12 @@ exec('psql', ['-c', 'grant all on database postgres_js_test to postgres_js_test'
 
 module.exports.exec = exec;function exec(cmd, args) {
   const { stderr } = spawnSync(cmd, args, { stdio: 'pipe', encoding: 'utf8' })
-  if (stderr && !stderr.includes('already exists') && !stderr.includes('does not exist'))
+  if (
+    stderr &&
+    !stderr.includes('already exists') &&
+    !stderr.includes('does not exist') &&
+    !stderr.includes('already a member of')
+  )
     throw stderr
 }
 

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -8,7 +8,7 @@ const crypto = require('crypto')
 const postgres = require('../src/index.js')
 const delay = ms => new Promise(r => setTimeout(r, ms))
 
-const rel = x => require('path').join(__dirname, x)
+const rel = x => require("path").join(__dirname, x)
 const idle_timeout = 1
 
 const login = {
@@ -2435,6 +2435,22 @@ t('Does not try rollback when commit errors', async() => {
   ]
 })
 
+
+t('Table created on transaction with role option belongs to role', async() => {
+  await sql.begin({ role: 'postgres_js_test_set_role' }, async sql => {
+    await sql`create table test (x int);`
+  })
+  const [{ tableowner }]  = await sql`select tableowner from pg_tables where tablename = 'test';`
+
+  return [
+    tableowner,
+    'postgres_js_test_set_role',
+    await sql`drop table test`
+  ]
+})
+
+
+
 t('Last keyword used even with duplicate keywords', async() => {
   await sql`create table test (x int)`
   await sql`insert into test values(1)`
@@ -2476,4 +2492,25 @@ t('Insert array with undefined transform', async() => {
     (await sql`select x from test`)[0].x[0],
     await sql`drop table test`
   ]
+})
+
+t('concurrent cursors', async() => {
+  const xs = []
+
+  await Promise.all([...Array(7)].map((x, i) => [
+    sql`select ${ i }::int as a, generate_series(1, 2) as x`.cursor(([x]) => xs.push(x.a + x.x))
+  ]).flat())
+
+  return ['12233445566778', xs.join('')]
+})
+
+t('concurrent cursors multiple connections', async() => {
+  const sql = postgres({ ...options, max: 2 })
+  const xs = []
+
+  await Promise.all([...Array(7)].map((x, i) => [
+    sql`select ${ i }::int as a, generate_series(1, 2) as x`.cursor(([x]) => xs.push(x.a + x.x))
+  ]).flat())
+
+  return ['12233445566778', xs.sort().join('')]
 })

--- a/deno/README.md
+++ b/deno/README.md
@@ -524,6 +524,28 @@ If you know what you're doing, you can use `unsafe` to pass any string you'd lik
 ```js
 sql.unsafe('select ' + danger + ' from users where id = ' + dragons)
 ```
+  
+You can also nest `sql.unsafe` within a safe `sql` expression.  This is useful if only part of your fraction has unsafe elements.
+
+```js
+const triggerName = 'friend_created'
+const triggerFnName = 'on_friend_created'
+const eventType = 'insert'
+const schema_name = 'app'
+const table_name = 'friends'
+
+await sql`
+  create or replace trigger ${sql(triggerName)}
+  after ${sql.unsafe(eventType)} on ${sql.unsafe(`${schema_name}.${table_name}`)}
+  for each row
+  execute function ${sql(triggerFnName)}()
+`
+
+await sql`
+  create role friend_service with login password ${sql.unsafe(`'${password}'`)}
+`
+```
+
 </details>
 
 ## Transactions

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -170,6 +170,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       build(q)
       return write(toBuffer(q))
         && !q.describeFirst
+        && !q.cursorFn
         && sent.length < max_pipeline
         && (!q.options.onexecute || q.options.onexecute(connection))
     } catch (error) {

--- a/deno/src/index.js
+++ b/deno/src/index.js
@@ -205,12 +205,16 @@ function Postgres(a, b) {
 
   async function begin(options, fn) {
     !fn && (fn = options, options = '')
+    if (typeof options === 'string') options = { beginOptions: options }
+    !options.beginOptions && (options.beginOptions = '')
+
     const queries = Queue()
     let savepoints = 0
       , connection
 
     try {
-      await sql.unsafe('begin ' + options.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
+      await sql.unsafe('begin ' + options.beginOptions.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
+      options.role && await sql`SET ROLE ${sql(options.role)};`
       return await scope(connection, fn)
     } catch (error) {
       throw error

--- a/deno/tests/bootstrap.js
+++ b/deno/tests/bootstrap.js
@@ -8,6 +8,8 @@ await exec('psql', ['-c', 'create user postgres_js_test_md5 with password \'post
 await exec('psql', ['-c', 'alter system set password_encryption=\'scram-sha-256\''])
 await exec('psql', ['-c', 'select pg_reload_conf()'])
 await exec('psql', ['-c', 'create user postgres_js_test_scram with password \'postgres_js_test_scram\''])
+await exec('psql', ['-c', 'create role postgres_js_test_set_role'])
+await exec('psql', ['-c', 'grant postgres_js_test_set_role TO postgres_js_test'])
 
 await exec('dropdb', ['postgres_js_test'])
 await exec('createdb', ['postgres_js_test'])
@@ -15,7 +17,12 @@ await exec('psql', ['-c', 'grant all on database postgres_js_test to postgres_js
 
 function ignore(cmd, args) {
   const { stderr } = spawnSync(cmd, args, { stdio: 'pipe', encoding: 'utf8' })
-  if (stderr && !stderr.includes('already exists') && !stderr.includes('does not exist'))
+  if (
+    stderr &&
+    !stderr.includes('already exists') &&
+    !stderr.includes('does not exist') &&
+    !stderr.includes('already a member of')
+  )
     throw stderr
 }
 

--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -639,6 +639,8 @@ declare namespace postgres {
   | SerializableParameter<T>
   | Fragment
 
+  type BeginOptions = string | { beginOptions?: string, role?: string }
+
   interface Sql<TTypes extends Record<string, unknown> = {}> {
     /**
      * Query helper
@@ -678,7 +680,7 @@ declare namespace postgres {
     largeObject(oid?: number | undefined, /** @default 0x00020000 | 0x00040000 */ mode?: number | undefined): Promise<LargeObject>;
 
     begin<T>(cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
-    begin<T>(options: string, cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
+    begin<T>(options: BeginOptions, cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
 
     array<T extends SerializableParameter<TTypes[keyof TTypes]>[] = SerializableParameter<TTypes[keyof TTypes]>[]>(value: T, type?: number | undefined): ArrayParameter<T>;
     file<T extends readonly any[] = Row[]>(path: string | Buffer | URL | number, options?: { cache?: boolean | undefined } | undefined): PendingQuery<T>;

--- a/src/index.js
+++ b/src/index.js
@@ -204,12 +204,16 @@ function Postgres(a, b) {
 
   async function begin(options, fn) {
     !fn && (fn = options, options = '')
+    if (typeof options === 'string') options = { beginOptions: options }
+    !options.beginOptions && (options.beginOptions = '')
+
     const queries = Queue()
     let savepoints = 0
       , connection
 
     try {
-      await sql.unsafe('begin ' + options.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
+      await sql.unsafe('begin ' + options.beginOptions.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
+      options.role && await sql`SET ROLE ${sql(options.role)};`
       return await scope(connection, fn)
     } catch (error) {
       throw error

--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -8,6 +8,8 @@ exec('psql', ['-c', 'create user postgres_js_test_md5 with password \'postgres_j
 exec('psql', ['-c', 'alter system set password_encryption=\'scram-sha-256\''])
 exec('psql', ['-c', 'select pg_reload_conf()'])
 exec('psql', ['-c', 'create user postgres_js_test_scram with password \'postgres_js_test_scram\''])
+exec('psql', ['-c', 'create role postgres_js_test_set_role'])
+exec('psql', ['-c', 'grant postgres_js_test_set_role TO postgres_js_test'])
 
 exec('dropdb', ['postgres_js_test'])
 exec('createdb', ['postgres_js_test'])
@@ -15,7 +17,12 @@ exec('psql', ['-c', 'grant all on database postgres_js_test to postgres_js_test'
 
 export function exec(cmd, args) {
   const { stderr } = spawnSync(cmd, args, { stdio: 'pipe', encoding: 'utf8' })
-  if (stderr && !stderr.includes('already exists') && !stderr.includes('does not exist'))
+  if (
+    stderr &&
+    !stderr.includes('already exists') &&
+    !stderr.includes('does not exist') &&
+    !stderr.includes('already a member of')
+  )
     throw stderr
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -2435,6 +2435,19 @@ t('Does not try rollback when commit errors', async() => {
   ]
 })
 
+t('Table created on transaction with options should belong to role', async() => {
+  await sql.begin({ role: 'postgres_js_test_set_role' }, async sql => {
+    await sql`create table test (x int);`
+  })
+  const [{ tableowner }]  = await sql`select tableowner from pg_tables where tablename = 'test';`
+
+  return [
+    tableowner,
+    'postgres_js_test_set_role',
+    await sql`drop table test`
+  ]
+})
+
 t('Last keyword used even with duplicate keywords', async() => {
   await sql`create table test (x int)`
   await sql`insert into test values(1)`

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -637,6 +637,8 @@ declare namespace postgres {
   | SerializableParameter<T>
   | Fragment
 
+  type BeginOptions = string | { beginOptions?: string, role?: string }
+
   interface Sql<TTypes extends Record<string, unknown> = {}> {
     /**
      * Query helper
@@ -676,7 +678,7 @@ declare namespace postgres {
     largeObject(oid?: number | undefined, /** @default 0x00020000 | 0x00040000 */ mode?: number | undefined): Promise<LargeObject>;
 
     begin<T>(cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
-    begin<T>(options: string, cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
+    begin<T>(options: BeginOptions, cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
 
     array<T extends SerializableParameter<TTypes[keyof TTypes]>[] = SerializableParameter<TTypes[keyof TTypes]>[]>(value: T, type?: number | undefined): ArrayParameter<T>;
     file<T extends readonly any[] = Row[]>(path: string | Buffer | URL | number, options?: { cache?: boolean | undefined } | undefined): PendingQuery<T>;


### PR DESCRIPTION
I really wanted to be able to set the transaction role before running the queries proper, for instance in my use case, I intend to only expose an transaction with the role already set, so even if someone uses admin credentials to start the application, it will still run all commands using the proper permissions.

It maintains compatibility with `sql.begin` and prepares for further extension.
P.s.: Some changes on language dirs are from previous commits 