### PR TITLE
README.md - improve the "Multiple statements in one query" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,9 +455,14 @@ const result = await sql.file('query.sql', ['Murray', 68])
 ```
 
 ### Multiple statements in one query
-#### `await sql`select 1;select 2`.simple()
+#### ```await sql``.simple()```
 
-The postgres wire protocol supports "simple" and "extended" queries. "simple" queries supports multiple statements, but does not support any dynamic parameters. "extended" queries support parameters but only one statement. To use "simple" queries you can use sql``.simple(). That will create it as a simple query.
+The postgres wire protocol supports ["simple"](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.6.7.4) and ["extended"](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY) queries. "simple" queries supports multiple statements, but does not support any dynamic parameters. "extended" queries support parameters but only one statement. To use "simple" queries you can use 
+```sql``.simple()```. That will create it as a simple query.
+
+```js
+await sql`select 1; select 2;`.simple()
+```
 
 ### Copy to/from as Streams
 


### PR DESCRIPTION
- add links for the official documentation
- escape the backtick character
- change the subtitle to "await sql``.simple()" instead of "await sql`select 1; select 2;`.simple()" (to be coherent with the other subtitles)
- add a small example below

before

![Screenshot_2023-06-26_11-16-08-before](https://github.com/porsager/postgres/assets/2184309/589c7e76-e34a-4faf-bf43-4ac71e9ee258)

after

![Screenshot_2023-06-26_11-15-58-after](https://github.com/porsager/postgres/assets/2184309/a4e6baea-d810-4854-b01b-f3f696e6c222)

