### PR TITLE
Update README.md (prepared transactions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ const user = {
   age: 68
 }
 
-sql`
+await sql`
   insert into users ${
     sql(user, 'name', 'age')
   }
@@ -183,6 +183,15 @@ sql`
 
 // Which results in:
 insert into users ("name", "age") values ($1, $2)
+
+// The columns can also be given with an array
+const columns = ['name', 'age']
+
+await sql`
+  insert into users ${
+    sql(user, columns)
+  }
+`
 ```
 
 **You can omit column names and simply execute `sql(user)` to get all the fields from the object as columns**. Be careful not to allow users to supply columns that you do not want to be inserted.
@@ -222,7 +231,7 @@ const user = {
   age: 68
 }
 
-sql`
+await sql`
   update users set ${
     sql(user, 'name', 'age')
   }
@@ -231,6 +240,16 @@ sql`
 
 // Which results in:
 update users set "name" = $1, "age" = $2 where user_id = $3
+
+// The columns can also be given with an array
+const columns = ['name', 'age']
+
+await sql`
+  update users set ${
+    sql(user, columns)
+  }
+  where user_id = ${ user.id }
+`
 ```
 
 ### Multiple updates in one query
@@ -593,6 +612,8 @@ const [user, account] = await sql.begin(async sql => {
 })
 ```
 
+Do note that you can often achieve the same result using [`WITH` queries (Common Table Expressions)](https://www.postgresql.org/docs/current/queries-with.html) instead of using transactions (see [example](https://dba.stackexchange.com/questions/199916/multiple-insert-queries-after-a-set-of-withs/199917#199917)).
+
 It's also possible to pipeline the requests in a transaction if needed by returning an array with queries from the callback function like this:
 
 ```js
@@ -656,8 +677,6 @@ sql.begin('read write', async sql => {
   await sql.prepare('tx1')
 })
 ```
-
-Do note that you can often achieve the same result using [`WITH` queries (Common Table Expressions)](https://www.postgresql.org/docs/current/queries-with.html) instead of using transactions.
 
 ## Data Transformation
 

--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ const [user, account] = await sql.begin(async sql => {
 })
 ```
 
-Do note that you can often achieve the same result using [`WITH` queries (Common Table Expressions)](https://www.postgresql.org/docs/current/queries-with.html) instead of using transactions (see [example](https://dba.stackexchange.com/questions/199916/multiple-insert-queries-after-a-set-of-withs/199917#199917)).
+Do note that you can often achieve the same result using [`WITH` queries (Common Table Expressions)](https://www.postgresql.org/docs/current/queries-with.html) instead of using transactions.
 
 It's also possible to pipeline the requests in a transaction if needed by returning an array with queries from the callback function like this:
 

--- a/README.md
+++ b/README.md
@@ -638,9 +638,9 @@ sql.begin('read write', async sql => {
 ```
 
 
-#### PREPARE `await sql.prepare([name]) -> fn()`
+#### PREPARE TRANSACTION `await sql.prepare([name]) -> fn()`
 
-Indicates that the transactions should be prepared using the `PREPARED TRANASCTION [NAME]` statement
+Indicates that the transactions should be prepared using the [`PREPARE TRANSACTION [NAME]`](https://www.postgresql.org/docs/current/sql-prepare-transaction.html) statement
 instead of being committed.
 
 ```js


### PR DESCRIPTION
- correct typo
- add link to the official docs
- change the subsection name to "PREPARE TRANSACTION" instead of "PREPARE" (because "PREPARE" is more associated with "prepared statements")

One thing that is still a bit confusing in this section is the final sentence "Do note that you can often achieve...". It seems like it is referring to the "PREPARE" subsection, but in reality it is referring to the initial "BEGIN / COMMIT" subsection, no?