### PR TITLE
Update README.md (Transactions added missing returning *)

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ const [user, account] = await sql.begin(async sql => {
     ) values (
       'Murray'
     )
+  returning *
   `
 
   const [account] = await sql`
@@ -587,6 +588,7 @@ const [user, account] = await sql.begin(async sql => {
     ) values (
       ${ user.user_id }
     )
+  returning *
   `
 
   return [user, account]


### PR DESCRIPTION
Check issue: https://github.com/porsager/postgres/issues/649

This is a minor modification but debugging this has taken a couple of hours for me as I am slightly new to SQL syntax and to postgreSQL in general. I was trying to use the empty return from sql.begin but it turned out that the callback in sql.begin was the one returning the empty array even though the insert was successful.