### PR TITLE
Fix connection on deno 1.36.3

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -129,7 +129,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     try {
       x = options.socket
         ? (await Promise.resolve(options.socket(options)))
-        : net.Socket()
+        : new net.Socket()
     } catch (e) {
       error(e)
       return


### PR DESCRIPTION
Running the following code on deno 1.36.3 using postgres 3.3.5:

```javascript
import postgres from "postgres";

const sql = postgres();

sql`SELECT 1`.then((result) => {
  console.log(result);
});

export default sql;
```

Gave the following error:

```
error: Uncaught (in promise) TypeError: Class constructor Socket cannot be invoked without 'new'
    at createSocket (./node_modules/.deno/postgres@3.3.5/node_modules/postgres/src/connection.js:131:15)
    at Timeout.connect [as _onTimeout] (./node_modules/.deno/postgres@3.3.5/node_modules/postgres/src/connection.js:328:31)
    at cb (ext:deno_node/internal/timers.mjs:63:31)
    at Object.action (ext:deno_web/02_timers.js:153:11)
    at handleTimerMacrotask (ext:deno_web/02_timers.js:67:10)
    at eventLoopTick (ext:core/01_core.js:189:21)
```

Simple fix is as proposed. Also tested if it still works in node v20.5.1, which it does :)