### PR TITLE
Fix #674 TypeScript issues with dynamic inserts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -177,9 +177,17 @@ type Rest<T> =
   T extends TemplateStringsArray ? never : // force fallback to the tagged template function overload
   T extends string ? readonly string[] :
   T extends readonly any[][] ? readonly [] :
-  T extends readonly (object & infer R)[] ? readonly (Keys & keyof R)[] :
+  T extends readonly (object & infer R)[] ? (
+    readonly (Keys & keyof R)[]   // sql(data, "prop", "prop2") syntax
+    |
+    [readonly (Keys & keyof R)[]] // sql(data, ["prop", "prop2"]) syntax
+  ) :
   T extends readonly any[] ? readonly [] :
-  T extends object ? readonly (Keys & keyof T)[] :
+  T extends object ? (
+    readonly (Keys & keyof T)[]   // sql(data, "prop", "prop2") syntax
+    |
+    [readonly (Keys & keyof T)[]] // sql(data, ["prop", "prop2"]) syntax
+  ) :
   any
 
 type Return<T, K extends readonly any[]> =


### PR DESCRIPTION
Fixes #674 

The problem was caused by the nature of how rest operator `...` is treated in TypeScript, implying `readonly (Keys & keyof R)[]` to represent individual function arguments. 

`[readonly (Keys & keyof R)[]]` represents exactly one argument of type `readonly (Keys & keyof R)[]`