### PR TITLE
Add common parameter names to ConnectionParameters TS type

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,7 +975,7 @@ const sql = postgres('postgres://username:password@host:port/database', {
   },
   connection           : {
     application_name   : 'postgres.js', // Default application_name
-    ...                                 // Other connection parameters
+    ...                                 // Other connection parameters, see https://www.postgresql.org/docs/current/runtime-config-client.html
   },
   target_session_attrs : null,          // Use 'read-write' with multiple hosts to
                                         // ensure only connecting to primary

--- a/deno/README.md
+++ b/deno/README.md
@@ -971,7 +971,7 @@ const sql = postgres('postgres://username:password@host:port/database', {
   },
   connection           : {
     application_name   : 'postgres.js', // Default application_name
-    ...                                 // Other connection parameters
+    ...                                 // Other connection parameters, see https://www.postgresql.org/docs/current/runtime-config-client.html
   },
   target_session_attrs : null,          // Use 'read-write' with multiple hosts to
                                         // ensure only connecting to primary

--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -331,8 +331,18 @@ declare namespace postgres {
      * @default 'postgres.js'
      */
     application_name: string;
+    default_transaction_isolation: 'read uncommitted' | 'read committed' | 'repeatable read' | 'serializable',
+    default_transaction_read_only: boolean,
+    default_transaction_deferrable: boolean,
+    statement_timeout: number,
+    lock_timeout: number,
+    idle_in_transaction_session_timeout: number,
+    idle_session_timeout: number,
+    DateStyle: string,
+    IntervalStyle: string,
+    TimeZone: string,
     /** Other connection parameters */
-    [name: string]: string;
+    [name: string]: string | number | boolean;
   }
 
   interface Options<T extends Record<string, postgres.PostgresType>> extends Partial<BaseOptions<T>> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -329,8 +329,18 @@ declare namespace postgres {
      * @default 'postgres.js'
      */
     application_name: string;
+    default_transaction_isolation: 'read uncommitted' | 'read committed' | 'repeatable read' | 'serializable',
+    default_transaction_read_only: boolean,
+    default_transaction_deferrable: boolean,
+    statement_timeout: number,
+    lock_timeout: number,
+    idle_in_transaction_session_timeout: number,
+    idle_session_timeout: number,
+    DateStyle: string,
+    IntervalStyle: string,
+    TimeZone: string,
     /** Other connection parameters */
-    [name: string]: string;
+    [name: string]: string | number | boolean;
   }
 
   interface Options<T extends Record<string, postgres.PostgresType>> extends Partial<BaseOptions<T>> {


### PR DESCRIPTION
fixes #645

- added reference to [Client Connection Defaults PostgreSQL documentation](https://www.postgresql.org/docs/current/runtime-config-client.html) to the readme
- added common (often used from my experience) parameter names directly to the `ConnectionParameters` type
- changed value type of parameter from just `string` to `string | number | boolean` - number and boolean works too