### PR TITLE
add "bun" export condition and set "types" exports first as ts 4.7 requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "module": "src/index.js",
   "main": "cjs/src/index.js",
   "exports": {
-    "worker": "./cf/src/index.js",
     "types": "./types/index.d.ts",
+    "bun": "./src/index.js",
+    "worker": "./cf/src/index.js",
     "import": "./src/index.js",
     "default": "./cjs/src/index.js"
   },


### PR DESCRIPTION
Closes #692 

Bun auto-matches a few conditions, including "worker" and "node". It looks for itself ("bun") first.
> See: https://bun.sh/docs/runtime/modules#importing-packages

Also made `types` the first condition, which is required according to the [TS 4.7 announcement blog](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-beta/)