### PR TITLE
Remove FLUSH from CF integration

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -93,6 +93,17 @@ export function handleValue(x, parameters, types, options) {
   ))
 }
 
+export function typesMapped(args, types) {
+  if (types.length < args.length) return false;
+  for(let i = 0; i < args.length; i++) {
+    let val = args[i] instanceof Parameter ? args[i].value : args[i]
+    if (types[i] === 0 && typeof val !== 'number') {
+      return false;
+    }
+  }
+  return true;
+}
+
 const defaultHandlers = typeHandlers(types)
 
 export function stringify(q, string, value, parameters, types, options) { // eslint-disable-line

--- a/tests/index.js
+++ b/tests/index.js
@@ -1588,7 +1588,7 @@ t('Error contains query string', async() => [
 ])
 
 t('Error contains query serialized parameters', async() => [
-  1,
+  '1',
   (await sql`selec ${ 1 }`.catch(err => err.parameters[0]))
 ])
 


### PR DESCRIPTION
The intermediate use of `FLUSH` in the current implementation for Cloudflare workers causes incompatibilities with Hyperdrive's caching service.

In order to support caching, this PR aims to remove the intermediate use of `FLUSH` when executing extended Postgres queries favoring sending the query all-together. This allows Hyperdrive's caching service to cache the full queries sent and serve results from cache for extended queries, resulting in less round-trips overall.

I believe all existing tests should pass (I ported the connection.js changes onto the deno implementation and ran the tests there). I also ran local tests to ensure compatibility. 