### PR TITLE
Patch: Connection stuck after a while

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -429,10 +429,9 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     lifeTimer.cancel()
     connectTimer.cancel()
 
-    if (socket.encrypted) {
+    if (socket.encrypted)
       socket.removeAllListeners()
-      socket = null
-    }
+    socket = null
 
     if (initial)
       return reconnect()

--- a/src/connection.js
+++ b/src/connection.js
@@ -429,8 +429,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     lifeTimer.cancel()
     connectTimer.cancel()
 
-    if (socket.encrypted)
-      socket.removeAllListeners()
+    socket.removeAllListeners()
     socket = null
 
     if (initial)


### PR DESCRIPTION
Hey @porsager

I noticed that, after a while, I had random "WRITE_TIMEOUT" // "CONNECT_TIMEOUT" happening and my system became unresposive.

It appears that the socket, once closed, doesn't correctly reconnect. By recreating the socket, it looks like it solved the issue. Today, this behavior is done only on "secured" but I believe we could have it for all connections.

I believe it's ok to do so as 1) it shouldn't happen often 2) socket is closed and will eventually be garbage collected 3) it's already done for secured connections

## Reproducing & checks
Context: I'm using Bun
I started with Postgres down - and started postgres after the first attempt to try to reproduce #641

**⚠️ It looks like this behavior doesn't happen on Node** - when using node with or without my patch, the socket correctly reconnects. I believe it may be solved by some Node shenanigan and impacting Bun (or even Worker?) only.

```javascript
import postgres from 'postgres'

const sql = postgres(`${process.env['DATABASE_URL']}`, {
    max: 1, # trigger the issue sooner
    max_lifetime: 1, # trigger the issue sooner by closing the connection really quickly
})

setInterval(async () => {
    console.log((await sql`SELECT * FROM pg_am`)[0])
}, 3000)
```

### Before
After the first query - connection is closed (because of `max_lifetime: 1`) and doesn't reconnect
![image](https://github.com/porsager/postgres/assets/135170502/e98d4efb-1583-4656-afe1-f499bf3dbf42)

### After
It reconnects well.
![image](https://github.com/porsager/postgres/assets/135170502/f5eec99b-fbd7-4155-836a-5cd731fbf9bc)


