### PR TITLE
add error handler to subscribe

### DIFF
--- a/src/subscribe.js
+++ b/src/subscribe.js
@@ -47,7 +47,7 @@ export default function Subscribe(postgres, options) {
 
   return subscribe
 
-  async function subscribe(event, fn, onsubscribe = noop) {
+  async function subscribe(event, fn, onsubscribe = noop, onerror = noop) {
     event = parseEvent(event)
 
     if (!connection)
@@ -66,6 +66,7 @@ export default function Subscribe(postgres, options) {
     return connection.then(x => {
       connected(x)
       onsubscribe()
+      stream && stream.on('error', onerror)
       return { unsubscribe, state, sql }
     })
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -690,7 +690,7 @@ declare namespace postgres {
     listen(channel: string, onnotify: (value: string) => void, onlisten?: (() => void) | undefined): ListenRequest;
     notify(channel: string, payload: string): PendingRequest;
 
-    subscribe(event: string, cb: (row: Row | null, info: ReplicationEvent) => void, onsubscribe?: (() => void) | undefined): Promise<SubscriptionHandle>;
+    subscribe(event: string, cb: (row: Row | null, info: ReplicationEvent) => void, onsubscribe?: (() => void), onerror?: (() => any)): Promise<SubscriptionHandle>;
 
     largeObject(oid?: number | undefined, /** @default 0x00020000 | 0x00040000 */ mode?: number | undefined): Promise<LargeObject>;
 


### PR DESCRIPTION
Related to https://github.com/porsager/postgres/issues/757.

Expose a error handler on the subscribe function so any error happened while streaming replica can be handled in user space.