### PR TITLE
docs: update Cloudflare Workers instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,10 +1103,10 @@ export default async fetch(req: Request, env: Env, ctx: ExecutionContext) {
 }
 ```
 
-In `wrangler.toml` you will need to enable `node_compat` to allow Postgres.js to operate in the Workers environment:
+In `wrangler.toml` you will need to enable the `nodejs_compat` compatibility flag to allow Postgres.js to operate in the Workers environment:
 
 ```toml
-node_compat = true # required for database drivers to function
+compatibility_flags = ["nodejs_compat"]
 ```
 
 ### Auto fetching of array types


### PR DESCRIPTION
With Cloudflare Workers, `node_compat` is an old paradigm that injects a lot of things into the global namespace that aren't necessary here, and existed before Cloudflare had more native support for Node.js APIs.

`nodejs_compat` is [much more modern](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) and Cloudflare's solution for actually using Node.js modules, and what this library uses when it imports from things like [`node:events`](https://github.com/porsager/postgres/blob/6f20a4820c683b33e7670b606d8daf5670f4b973/cf/polyfills.js#L1), etc.

The tests referenced for the Cloudflare implementation here also use `nodejs_compat`, not `node_compat`: https://github.com/porsager/postgres/blob/6f20a4820c683b33e7670b606d8daf5670f4b973/cf/test.js#L2

I've tested with many of my own projects, and only `nodejs_compat` is needed. You in fact can't use both the older `node_compat` and newer `nodejs_compat`, so I would recommend encouraging use of the newer paradigm here.