### PR TITLE
corrects explnation of default max_lifetime values in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,7 +992,7 @@ const sql = postgres('postgres://username:password@host:port/database', {
 })
 ```
 
-Note that `max_lifetime = 60 * (30 + Math.random() * 30)` by default. This resolves to an interval between 45 and 90 minutes to optimize for the benefits of prepared statements **and** working nicely with Linux's OOM killer.
+Note that `max_lifetime = 60 * (30 + Math.random() * 30)` by default. This resolves to an interval between 30 and 60 minutes to optimize for the benefits of prepared statements **and** working nicely with Linux's OOM killer.
 
 ### Dynamic passwords
 

--- a/deno/README.md
+++ b/deno/README.md
@@ -988,7 +988,7 @@ const sql = postgres('postgres://username:password@host:port/database', {
 })
 ```
 
-Note that `max_lifetime = 60 * (30 + Math.random() * 30)` by default. This resolves to an interval between 45 and 90 minutes to optimize for the benefits of prepared statements **and** working nicely with Linux's OOM killer.
+Note that `max_lifetime = 60 * (30 + Math.random() * 30)` by default. This resolves to an interval between 30 and 60 minutes to optimize for the benefits of prepared statements **and** working nicely with Linux's OOM killer.
 
 ### Dynamic passwords
 


### PR DESCRIPTION
The current version of the README states:
> Note that `max_lifetime = 60 * (30 + Math.random() * 30)` by default. This resolves to an interval between 45 and 90 minutes to optimize for the benefits of prepared statements **and** working nicely with Linux's OOM killer.

The range of `60 * (30 + Math.random() * 30)` is 1800-3600, therefore 30 to 60 minutes.

<details>
<summary>Both versions define the max_lifetime as 60 * (30 + Math.random() * 30)</summary>

https://github.com/porsager/postgres/blob/cc688c642fc98c4338523d3e281e03bf0c3417b8/deno/src/index.js#L515

https://github.com/porsager/postgres/blob/cc688c642fc98c4338523d3e281e03bf0c3417b8/src/index.js#L514

</details>
