### PR TITLE
fix(types): use correct default export

### DIFF
--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -728,4 +728,4 @@ declare namespace postgres {
   }
 }
 
-export = postgres;
+export default postgres;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -726,4 +726,4 @@ declare namespace postgres {
   }
 }
 
-export = postgres;
+export default postgres;


### PR DESCRIPTION
This PR fixes #862 by ensuring classes defined under the `postgres` namespace aren't also available as a named export, but only under the default `postgres.` export.

I've tested the change by patching the module in my projects, but I'm not sure if under some specific Typescript scenarios the behaviour could be incorrect.

---

Trying to import `PostgresError` as a named export:

<img width="578" alt="Screenshot 2024-06-24 at 12 30 01" src="https://github.com/porsager/postgres/assets/59444760/234b5f7f-1e3c-4576-a40f-5be9b5e96c1a">

---

And here's the correct usage using the default export:

<img width="556" alt="Screenshot 2024-06-24 at 12 31 14" src="https://github.com/porsager/postgres/assets/59444760/29486430-af2f-437f-a1c8-40b3e67a3f29">
