### PR TITLE
Adding PGAPPNAME Environment Variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## v3.3.0 - 9 July 2024
-- Adding support for the PGAPPNAME environment variable
-
 ## v3.2.4 - 25 May 2022
 - Allow setting keep_alive: false  bee62f3
 - Fix support for null in arrays - fixes #371  b04c853

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.3.0 - 9 July 2024
+- Adding support for the PGAPPNAME environment variable
+
 ## v3.2.4 - 25 May 2022
 - Allow setting keep_alive: false  bee62f3
 - Fix support for null in arrays - fixes #371  b04c853

--- a/README.md
+++ b/README.md
@@ -1125,15 +1125,16 @@ It is also possible to connect to the database without a connection string or an
 const sql = postgres()
 ```
 
-| Option            | Environment Variables    |
-| ----------------- | ------------------------ |
-| `host`            | `PGHOST`                 |
-| `port`            | `PGPORT`                 |
-| `database`        | `PGDATABASE`             |
-| `username`        | `PGUSERNAME` or `PGUSER` |
-| `password`        | `PGPASSWORD`             |
-| `idle_timeout`    | `PGIDLE_TIMEOUT`         |
-| `connect_timeout` | `PGCONNECT_TIMEOUT`      |
+| Option             | Environment Variables    |
+| ------------------ | ------------------------ |
+| `host`             | `PGHOST`                 |
+| `port`             | `PGPORT`                 |
+| `database`         | `PGDATABASE`             |
+| `username`         | `PGUSERNAME` or `PGUSER` |
+| `password`         | `PGPASSWORD`             |
+| `application_name` | `PGAPPNAME`              |
+| `idle_timeout`     | `PGIDLE_TIMEOUT`         |
+| `connect_timeout`  | `PGCONNECT_TIMEOUT`      |
 
 ### Prepared statements
 

--- a/src/index.js
+++ b/src/index.js
@@ -480,7 +480,7 @@ function parseOptions(a, b) {
       {}
     ),
     connection      : {
-      application_name: 'postgres.js',
+      application_name: env.PGUSERNAME || 'postgres.js',
       ...o.connection,
       ...Object.entries(query).reduce((acc, [k, v]) => (k in defaults || (acc[k] = v), acc), {})
     },

--- a/src/index.js
+++ b/src/index.js
@@ -480,7 +480,7 @@ function parseOptions(a, b) {
       {}
     ),
     connection      : {
-      application_name: env.PGUSERNAME || 'postgres.js',
+      application_name: env.PGAPPNAME || 'postgres.js',
       ...o.connection,
       ...Object.entries(query).reduce((acc, [k, v]) => (k in defaults || (acc[k] = v), acc), {})
     },


### PR DESCRIPTION
Making it possible to set the application_name with the PGAPPNAME environment variable. This is a standard set by the Postgres team (https://www.postgresql.org/docs/current/libpq-envars.html). 

It is a nice to have feature, and makes it easier to transition from the pg package 🔢 😊