### PR TITLE
Disable env when parsing options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -430,7 +430,7 @@ function parseOptions(a, b) {
   if (a && a.shared)
     return a
 
-  const env = process.env // eslint-disable-line
+  const env = (a.no_env || b.no_env) ? {} : process.env // eslint-disable-line
       , o = (!a || typeof a === 'string' ? b : a) || {}
       , { url, multihost } = parseUrl(a)
       , query = [...url.searchParams].reduce((a, [b, c]) => (a[b] = c, a), {})


### PR DESCRIPTION
Sometimes you have this library running in another computer with no control over the environment variables (A.K.A. user computer) and in a simple interface, the user expects for it to work as defined in the configuration, so an empty password input should be an empty password sent to postgres, not modified based on the environment variables.

Sometimes support tickets are tedious, so convincing a user that he has a `PGPASSWORD` env variable (for whatever reason) and the variable is affecting how he expects the configuration to work, is something I prefer to not fight for, hence I added a `no_env` property to the configuration to avoid applying the env values. It is opt-in so is nothing that could break anything, I guess. If this way is not good, I still would like to discuss ways to avoid env to apply, apart from modifying `process.env` prior to the parsing, if possible.