### PR TITLE
Dynamic Custom Type support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,8 @@ function Postgres(a, b) {
       notify,
       array,
       json,
-      file
+      file,
+      addType
     })
 
     return sql
@@ -562,4 +563,13 @@ function osUsername() {
   } catch (_) {
     return process.env.USERNAME || process.env.USER || process.env.LOGNAME  // eslint-disable-line
   }
+}
+
+async function addType(name, { serializer, parser }) {
+  const [{ oid }] = await this`
+    select oid from pg_type where typname = ${name} 
+  `;
+  this.typed[name] = (x) => this.typed(x, oid);
+  this.options.serializers[oid] = serializer;
+  this.options.parsers[oid] = parser;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -704,6 +704,8 @@ declare namespace postgres {
     json(value: JSONValue): Parameter;
 
     reserve(): Promise<ReservedSql<TTypes>>
+
+    addType<T>(name: string, handler: { serializer: (x: T) => any, parser: (x: any) => T}): void;
   }
 
   interface UnsafeQueryOptions {


### PR DESCRIPTION
This PR tries to solve two related issues in relation to custom types. 
1. Allow custom type to be added using type name instead of oid.
2. Allow custom type to be added after initialisation. 

Currently, to add a custom type one must know the oid of the type beforehand on initialisation. 
This introduces a chicken and egg problem. In order to get the oid one must have a working instance to query the pg_type table to begin without. In addition, if a type is created on database during a session, there is no way to add a matching type on the client side without recreate a new Sql instance. 

To solve this problem, this PR adds an addType function. For example
```js
 const sql = postgres(options)
  await sql.addType('point', {
    serializer: (v) => `(${v.x},${v.y})`,
    parser: (v) => {
      const [x, y] = v.slice(1, -1).split(',')
      return { x: parseFloat(x), y: parseFloat(y) }
    }
  })
  await sql`create table test (p point)`
  const data = { x: 1, y: 2 }
  await sql`insert into test values(${sql.typed.point(data)})`

  const [{ p }] = await sql`select p from test`
  const equal = p.x === data.x && p.y === data.y
```
The idea of this PR is simple. we delay the registration of custom type after sql initialise. then use that connection to query the pg_type to get the oid and use it to add serialiser and parser dynamically. 

One problem I am not sure how to solve is how merge the typescript definition of this new custom type into the existing `TTypes`.  Just throw it out first to see what everyone think.   