### PR TITLE
Add stub backpressure methods to Cloudflare polyfills

### DIFF
--- a/cf/polyfills.js
+++ b/cf/polyfills.js
@@ -139,6 +139,8 @@ function Socket() {
     write,
     end,
     destroy,
+    pause,
+    resume,
     read
   })
 
@@ -193,6 +195,10 @@ function Socket() {
     tcp.destroyed = true
     tcp.end()
   }
+
+  function pause() {}
+
+  function resume() {}
 
   async function read() {
     try {


### PR DESCRIPTION
Streaming data from a query in the CF environment crashes due to missing "pause" and "resume" methods in Socket's polyfill. As the underlying stream is a Web Stream, it seems to be safe to just stub these methods.