### PR TITLE
Enable dynamic column aliases

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -136,7 +136,9 @@ function values(first, rest, parameters, types, options) {
 function select(first, rest, parameters, types, options) {
   typeof first === 'string' && (first = [first].concat(rest))
   if (Array.isArray(first))
-    return escapeIdentifiers(first, options)
+    return first.map(x =>
+      Array.isArray(x) [escapeIdentifier(x[0], options),escapeIdentifier(x[1], options)].join(" AS ") : escapeIdentifier(x, options)
+    )
 
   let value
   const columns = rest.length ? rest.flat() : Object.keys(first)

--- a/src/types.js
+++ b/src/types.js
@@ -137,7 +137,7 @@ function select(first, rest, parameters, types, options) {
   typeof first === 'string' && (first = [first].concat(rest))
   if (Array.isArray(first))
     return first.map(x =>
-      Array.isArray(x) [escapeIdentifier(x[0], options),escapeIdentifier(x[1], options)].join(" AS ") : escapeIdentifier(x, options)
+      Array.isArray(x) [escapeIdentifiers([x[0]], options),escapeIdentifier(x[1], options)].join(" AS ") : escapeIdentifiers([x], options)
     )
 
   let value


### PR DESCRIPTION
Fixes #894.

Updates the parser to enable column aliases (i.e., "AS" statements) when columns are given in a dynamic array).

The syntax uses a nested array with two elements:

```javascript
let columns = [];

if (view.field === "id") {
  columns.push("companies.id");
}

// ... other fields condition

if (view.field === "createdBy") {
  columns.push(["creator.email", "creatorEmail"]);
}
// columns = ["companies.id", ["creator.email", "creatorEmail"]]
sql`
  select
    ${sql(columns)}
  from
    companies
  join
    users as creator
  on
    companies."createdBy" = creator.id`
```
Which will produce:
```sql
SELECT "companies.id","creator.email" AS "creatorEmail"
FROM companies JOIN users as creator ON 
companies."createdBy" = creator.id
```
