### PR TITLE
Ensure connection is usable after COPY stream is complete

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -884,6 +884,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   function CopyDone() {
     stream && stream.push(null)
     stream = null
+    socket.isPaused() && socket.resume()
   }
 
   function NoticeResponse(x) {


### PR DESCRIPTION
## Summary
Encountered this issue in a live environment.
Sometimes random queries were hanging indefinitely after using a `COPY` stream.

This PR likely fixes:
- https://github.com/porsager/postgres/issues/499

## Cause
This was caused by receiving `CopyData` and `CopyDone` messages within the same chunk.
If `CopyData` triggers high water mark, handler pauses the socket, but still continues to process remaining messages, that were already received.
If `CopyDone` is handled before stream managed to process buffered messages, the connection becomes unusable - the socket is paused. Any query using that connection will hang indefinitely  (with response data in the socket read buffer).

## Fix
Make sure socket is flowing after `COPY` stream is done.
The test is a little complicated, but I couldn't find a simpler way to reliably reproduce the issue (now without the fix the test will timeout every time).
