### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           date
-          sudo apt purge postgresql-14
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           date
+          sudo apt purge postgresql-16
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update


### PR DESCRIPTION
`sudo apt purge postgresql-14` is currently failing with:
```bash
E: Unable to locate package postgresql-14
```

I am not sure if the command is necessary, but it seems CI is passing without it. 