### PR TITLE
✏️ fix CONNECT_TIMEOUT name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1303,8 +1303,8 @@ This error is thrown if the user has called [`sql.end()`](#teardown--cleanup) an
 
 This error is thrown for any queries that were pending when the timeout to [`sql.end({ timeout: X })`](#teardown--cleanup) was reached.
 
-##### CONNECTION_CONNECT_TIMEOUT
-> write CONNECTION_CONNECT_TIMEOUT host:port
+##### CONNECT_TIMEOUT
+> write CONNECT_TIMEOUT host:port
 
 This error is thrown if the startup phase of the connection (tcp, protocol negotiation, and auth) took more than the default 30 seconds or what was specified using `connect_timeout` or `PGCONNECT_TIMEOUT`.
 


### PR DESCRIPTION
The `CONNECT_TIMEOUT` error's name is `CONNECT_TIMEOUT`, not `CONNECTION_CONNECT_TIMEOUT`, as can be seen [here](https://github.com/porsager/postgres/blob/master/src/connection.js#L257).