### PR TITLE
fix: add missing properties to reserve query

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -385,6 +385,9 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   function queryError(query, err) {
+    if (query === true) {
+      return;
+    }
     'query' in err || 'parameters' in err || Object.defineProperties(err, {
       stack: { value: err.stack + query.origin.replace(/.*\n/, '\n'), enumerable: options.debug },
       query: { value: query.string, enumerable: options.debug },

--- a/src/index.js
+++ b/src/index.js
@@ -204,9 +204,10 @@ function Postgres(a, b) {
     const queue = Queue()
     const c = open.length
       ? open.shift()
-      : await new Promise(r => {
-        queries.push({ reserve: r })
-        closed.length && connect(closed.shift())
+      : await new Promise((resolve, reject) => {
+        const q = { reserve: resolve, reject, origin: 'reserve() call', statement: {} };
+        queries.push(q);
+        closed.length && connect(closed.shift(), q)
       })
 
     move(c, reserved)


### PR DESCRIPTION
Fixes https://github.com/porsager/postgres/pull/944

The call to connect(c, query) had no query, so for a connection failure,  query.origin.replace would fail, crashing the process.