### PR TITLE
fix: Remove array support from inferType.

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -224,7 +224,6 @@ export const inferType = function inferType(x) {
     x instanceof Uint8Array ? 17 :
     (x === true || x === false) ? 16 :
     typeof x === 'bigint' ? 20 :
-    Array.isArray(x) ? inferType(x[0]) :
     0
   )
 }


### PR DESCRIPTION
I believe this was always broken, because the oid of a boolean[] is not the same as the oid of a boolean, and AFAICT inferType was resolving "boolean[] --> the oid of a boolean" without any attempt to translate over to the `boolean[]` oid.

There's talk of removing `inferType` entirely, which would have to wait until v4, but I think if this array-based support has always been broken (afaiu?), we can just remove it immediately in a v3 bug fix release.

Fixes #471