### PR TITLE
feat: Add onquery callback.

### DIFF
--- a/cf/src/connection.js
+++ b/cf/src/connection.js
@@ -167,6 +167,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         : (query = q, query.active = true)
 
       build(q)
+      q.onquery && (q.onquery = q.onquery(q))
       return write(toBuffer(q))
         && !q.describeFirst
         && !q.cursorFn

--- a/cf/src/index.js
+++ b/cf/src/index.js
@@ -86,6 +86,7 @@ function Postgres(a, b) {
 
   function Sql(handler) {
     handler.debug = options.debug
+    handler.onquery = options.onquery
 
     Object.entries(options.types).reduce((acc, [name, type]) => {
       acc[name] = (x) => new Parameter(x, type.to)
@@ -481,7 +482,7 @@ function parseOptions(a, b) {
       {}
     ),
     connection      : {
-      application_name: 'postgres.js',
+      application_name: env.PGAPPNAME || 'postgres.js',
       ...o.connection,
       ...Object.entries(query).reduce((acc, [k, v]) => (k in defaults || (acc[k] = v), acc), {})
     },
@@ -491,6 +492,7 @@ function parseOptions(a, b) {
     onnotify        : o.onnotify,
     onclose         : o.onclose,
     onparameter     : o.onparameter,
+    onquery         : o.onquery,
     socket          : o.socket,
     transform       : parseTransform(o.transform || { undefined: undefined }),
     parameters      : {},

--- a/cf/src/query.js
+++ b/cf/src/query.js
@@ -13,6 +13,9 @@ export class Query extends Promise {
       reject = b
     })
 
+    this.resolver = resolve
+    this.rejecter = reject
+
     this.tagged = Array.isArray(strings.raw)
     this.strings = strings
     this.args = args
@@ -23,17 +26,27 @@ export class Query extends Promise {
     this.state = null
     this.statement = null
 
-    this.resolve = x => (this.active = false, resolve(x))
-    this.reject = x => (this.active = false, reject(x))
-
     this.active = false
     this.cancelled = null
     this.executed = false
     this.signature = ''
+    this.onquery = this.handler.onquery
 
     this[originError] = this.handler.debug
       ? new Error()
       : this.tagged && cachedError(this.strings)
+  }
+
+  resolve(x) {
+    this.active = false
+    this.onquery && (this.onquery = this.onquery(x))
+    this.resolver(x)
+  }
+
+  reject(x) {
+    this.active = false
+    this.onquery && (this.onquery = this.onquery(x))
+    this.rejecter(x)
   }
 
   get origin() {
@@ -137,7 +150,13 @@ export class Query extends Promise {
   }
 
   async handle() {
-    !this.executed && (this.executed = true) && await 1 && this.handler(this)
+    if (this.executed)
+      return
+
+    this.executed = true
+    await 1
+    this.onquery && (this.onquery = this.onquery(this))
+    this.handler(this)
   }
 
   execute() {

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -165,6 +165,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         : (query = q, query.active = true)
 
       build(q)
+      q.onquery && (q.onquery = q.onquery(q))
       return write(toBuffer(q))
         && !q.describeFirst
         && !q.cursorFn

--- a/cjs/src/index.js
+++ b/cjs/src/index.js
@@ -85,6 +85,7 @@ function Postgres(a, b) {
 
   function Sql(handler) {
     handler.debug = options.debug
+    handler.onquery = options.onquery
 
     Object.entries(options.types).reduce((acc, [name, type]) => {
       acc[name] = (x) => new Parameter(x, type.to)
@@ -480,7 +481,7 @@ function parseOptions(a, b) {
       {}
     ),
     connection      : {
-      application_name: 'postgres.js',
+      application_name: env.PGAPPNAME || 'postgres.js',
       ...o.connection,
       ...Object.entries(query).reduce((acc, [k, v]) => (k in defaults || (acc[k] = v), acc), {})
     },
@@ -490,6 +491,7 @@ function parseOptions(a, b) {
     onnotify        : o.onnotify,
     onclose         : o.onclose,
     onparameter     : o.onparameter,
+    onquery         : o.onquery,
     socket          : o.socket,
     transform       : parseTransform(o.transform || { undefined: undefined }),
     parameters      : {},

--- a/deno/README.md
+++ b/deno/README.md
@@ -1121,19 +1121,24 @@ It is also possible to connect to the database without a connection string or an
 const sql = postgres()
 ```
 
-| Option            | Environment Variables    |
-| ----------------- | ------------------------ |
-| `host`            | `PGHOST`                 |
-| `port`            | `PGPORT`                 |
-| `database`        | `PGDATABASE`             |
-| `username`        | `PGUSERNAME` or `PGUSER` |
-| `password`        | `PGPASSWORD`             |
-| `idle_timeout`    | `PGIDLE_TIMEOUT`         |
-| `connect_timeout` | `PGCONNECT_TIMEOUT`      |
+| Option             | Environment Variables    |
+| ------------------ | ------------------------ |
+| `host`             | `PGHOST`                 |
+| `port`             | `PGPORT`                 |
+| `database`         | `PGDATABASE`             |
+| `username`         | `PGUSERNAME` or `PGUSER` |
+| `password`         | `PGPASSWORD`             |
+| `application_name` | `PGAPPNAME`              |
+| `idle_timeout`     | `PGIDLE_TIMEOUT`         |
+| `connect_timeout`  | `PGCONNECT_TIMEOUT`      |
 
 ### Prepared statements
 
 Prepared statements will automatically be created for any queries where it can be inferred that the query is static. This can be disabled by using the `prepare: false` option. For instance — this is useful when [using PGBouncer in `transaction mode`](https://github.com/porsager/postgres/issues/93#issuecomment-656290493).
+
+**update**: [since 1.21.0](https://www.pgbouncer.org/2023/10/pgbouncer-1-21-0)
+PGBouncer supports protocol-level named prepared statements when [configured
+properly](https://www.pgbouncer.org/config.html#max_prepared_statements)
 
 ## Custom Types
 
@@ -1294,8 +1299,8 @@ This error is thrown if the user has called [`sql.end()`](#teardown--cleanup) an
 
 This error is thrown for any queries that were pending when the timeout to [`sql.end({ timeout: X })`](#teardown--cleanup) was reached.
 
-##### CONNECTION_CONNECT_TIMEOUT
-> write CONNECTION_CONNECT_TIMEOUT host:port
+##### CONNECT_TIMEOUT
+> write CONNECT_TIMEOUT host:port
 
 This error is thrown if the startup phase of the connection (tcp, protocol negotiation, and auth) took more than the default 30 seconds or what was specified using `connect_timeout` or `PGCONNECT_TIMEOUT`.
 

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -168,6 +168,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         : (query = q, query.active = true)
 
       build(q)
+      q.onquery && (q.onquery = q.onquery(q))
       return write(toBuffer(q))
         && !q.describeFirst
         && !q.cursorFn

--- a/deno/src/index.js
+++ b/deno/src/index.js
@@ -86,6 +86,7 @@ function Postgres(a, b) {
 
   function Sql(handler) {
     handler.debug = options.debug
+    handler.onquery = options.onquery
 
     Object.entries(options.types).reduce((acc, [name, type]) => {
       acc[name] = (x) => new Parameter(x, type.to)
@@ -481,7 +482,7 @@ function parseOptions(a, b) {
       {}
     ),
     connection      : {
-      application_name: 'postgres.js',
+      application_name: env.PGAPPNAME || 'postgres.js',
       ...o.connection,
       ...Object.entries(query).reduce((acc, [k, v]) => (k in defaults || (acc[k] = v), acc), {})
     },
@@ -491,6 +492,7 @@ function parseOptions(a, b) {
     onnotify        : o.onnotify,
     onclose         : o.onclose,
     onparameter     : o.onparameter,
+    onquery         : o.onquery,
     socket          : o.socket,
     transform       : parseTransform(o.transform || { undefined: undefined }),
     parameters      : {},

--- a/deno/src/query.js
+++ b/deno/src/query.js
@@ -13,6 +13,9 @@ export class Query extends Promise {
       reject = b
     })
 
+    this.resolver = resolve
+    this.rejecter = reject
+
     this.tagged = Array.isArray(strings.raw)
     this.strings = strings
     this.args = args
@@ -23,17 +26,27 @@ export class Query extends Promise {
     this.state = null
     this.statement = null
 
-    this.resolve = x => (this.active = false, resolve(x))
-    this.reject = x => (this.active = false, reject(x))
-
     this.active = false
     this.cancelled = null
     this.executed = false
     this.signature = ''
+    this.onquery = this.handler.onquery
 
     this[originError] = this.handler.debug
       ? new Error()
       : this.tagged && cachedError(this.strings)
+  }
+
+  resolve(x) {
+    this.active = false
+    this.onquery && (this.onquery = this.onquery(x))
+    this.resolver(x)
+  }
+
+  reject(x) {
+    this.active = false
+    this.onquery && (this.onquery = this.onquery(x))
+    this.rejecter(x)
   }
 
   get origin() {
@@ -137,7 +150,13 @@ export class Query extends Promise {
   }
 
   async handle() {
-    !this.executed && (this.executed = true) && await 1 && this.handler(this)
+    if (this.executed)
+      return
+
+    this.executed = true
+    await 1
+    this.onquery && (this.onquery = this.onquery(this))
+    this.handler(this)
   }
 
   execute() {

--- a/src/connection.js
+++ b/src/connection.js
@@ -165,6 +165,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         : (query = q, query.active = true)
 
       build(q)
+      q.onquery && (q.onquery = q.onquery(q))
       return write(toBuffer(q))
         && !q.describeFirst
         && !q.cursorFn

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,7 @@ function Postgres(a, b) {
 
   function Sql(handler) {
     handler.debug = options.debug
+    handler.onquery = options.onquery
 
     Object.entries(options.types).reduce((acc, [name, type]) => {
       acc[name] = (x) => new Parameter(x, type.to)
@@ -490,6 +491,7 @@ function parseOptions(a, b) {
     onnotify        : o.onnotify,
     onclose         : o.onclose,
     onparameter     : o.onparameter,
+    onquery         : o.onquery,
     socket          : o.socket,
     transform       : parseTransform(o.transform || { undefined: undefined }),
     parameters      : {},

--- a/src/query.js
+++ b/src/query.js
@@ -13,6 +13,9 @@ export class Query extends Promise {
       reject = b
     })
 
+    this.resolver = resolve
+    this.rejecter = reject
+
     this.tagged = Array.isArray(strings.raw)
     this.strings = strings
     this.args = args
@@ -23,17 +26,27 @@ export class Query extends Promise {
     this.state = null
     this.statement = null
 
-    this.resolve = x => (this.active = false, resolve(x))
-    this.reject = x => (this.active = false, reject(x))
-
     this.active = false
     this.cancelled = null
     this.executed = false
     this.signature = ''
+    this.onquery = this.handler.onquery
 
     this[originError] = this.handler.debug
       ? new Error()
       : this.tagged && cachedError(this.strings)
+  }
+
+  resolve(x) {
+    this.active = false
+    this.onquery && (this.onquery = this.onquery(x))
+    this.resolver(x)
+  }
+
+  reject(x) {
+    this.active = false
+    this.onquery && (this.onquery = this.onquery(x))
+    this.rejecter(x)
   }
 
   get origin() {
@@ -137,7 +150,13 @@ export class Query extends Promise {
   }
 
   async handle() {
-    !this.executed && (this.executed = true) && await 1 && this.handler(this)
+    if (this.executed)
+      return
+
+    this.executed = true
+    await 1
+    this.onquery && (this.onquery = this.onquery(this))
+    this.handler(this)
   }
 
   execute() {


### PR DESCRIPTION
Based on @porsager 's `query-stats` branch with @abustany fixes. 

Disclaimers that:

1. I did not add tests, and
2. Currently the `onquery` accepts the Query instance as-is, which can be difficult for APM tools to look at "just give me the SQL string + params", so it might be worth passing in an API that is higher-level/easier-to-consume than the raw Query

Fixes #461.