### PR TITLE
fixed typings for generic error code variants

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -456,7 +456,8 @@ declare namespace postgres {
     | 'NOT_TAGGED_CALL'
     | 'UNDEFINED_VALUE'
     | 'MAX_PARAMETERS_EXCEEDED'
-    | 'SASL_SIGNATURE_MISMATCH';
+    | 'SASL_SIGNATURE_MISMATCH'
+    | 'UNSAFE_TRANSACTION';
     message: string;
   }
 


### PR DESCRIPTION
Added the missing [`UNSAFE_TRANSACTION`](https://github.com/porsager/postgres?tab=readme-ov-file#unsafe_transaction) code to the union of generic error code variants.