### PR TITLE
Fix PGAPPNAME env access by prioritizing connection.application_name

### DIFF
--- a/deno/src/index.js
+++ b/deno/src/index.js
@@ -482,8 +482,8 @@ function parseOptions(a, b) {
       {}
     ),
     connection      : {
-      application_name: env.PGAPPNAME || 'postgres.js',
       ...o.connection,
+      application_name: o.connection?.application_name ?? env.PGAPPNAME ?? 'postgres.js',
       ...Object.entries(query).reduce((acc, [k, v]) => (k in defaults || (acc[k] = v), acc), {})
     },
     types           : o.types || {},


### PR DESCRIPTION
Use connection.application_name if provided before falling back to PGAPPNAME env var to avoid unnecessary env access errors.