### PR TITLE
Fixes #789: Wait for DB type initialization before querying

### DIFF
--- a/cf/src/connection.js
+++ b/cf/src/connection.js
@@ -82,6 +82,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     , result = new Result()
     , incoming = Buffer.alloc(0)
     , needsTypes = options.fetch_types
+    , typesPromise = null
     , backendParameters = {}
     , statements = {}
     , statementId = Math.random().toString(36).slice(2)
@@ -541,12 +542,23 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       if (needsTypes) {
         initial.reserve && (initial = null)
-        return fetchArrayTypes()
+
+        // Prevent duplicate requests
+        needsTypes = false
+
+        // Store the promise so concurrent requests can wait for type initialization to complete
+        typesPromise = fetchArrayTypes().finally(() => {
+          typesPromise = null
+        })
+        return
       }
 
-      initial && !initial.reserve && execute(initial)
-      options.shared.retries = retries = 0
-      initial = null
+      // If there is a pending types request, trigger the execution after it's complete
+      (typesPromise || Promise.resolve()).then(() => {
+        initial && !initial.reserve && execute(initial)
+        options.shared.retries = retries = 0
+        initial = null
+      })
       return
     }
 

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -80,6 +80,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     , result = new Result()
     , incoming = Buffer.alloc(0)
     , needsTypes = options.fetch_types
+    , typesPromise = null
     , backendParameters = {}
     , statements = {}
     , statementId = Math.random().toString(36).slice(2)
@@ -539,12 +540,23 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       if (needsTypes) {
         initial.reserve && (initial = null)
-        return fetchArrayTypes()
+
+        // Prevent duplicate requests
+        needsTypes = false
+
+        // Store the promise so concurrent requests can wait for type initialization to complete
+        typesPromise = fetchArrayTypes().finally(() => {
+          typesPromise = null
+        })
+        return
       }
 
-      initial && !initial.reserve && execute(initial)
-      options.shared.retries = retries = 0
-      initial = null
+      // If there is a pending types request, trigger the execution after it's complete
+      (typesPromise || Promise.resolve()).then(() => {
+        initial && !initial.reserve && execute(initial)
+        options.shared.retries = retries = 0
+        initial = null
+      })
       return
     }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -80,6 +80,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     , result = new Result()
     , incoming = Buffer.alloc(0)
     , needsTypes = options.fetch_types
+    , typesPromise = null
     , backendParameters = {}
     , statements = {}
     , statementId = Math.random().toString(36).slice(2)
@@ -539,12 +540,23 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       if (needsTypes) {
         initial.reserve && (initial = null)
-        return fetchArrayTypes()
+
+        // Prevent duplicate requests
+        needsTypes = false
+
+        // Store the promise so concurrent requests can wait for type initialization to complete
+        typesPromise = fetchArrayTypes().finally(() => {
+          typesPromise = null
+        })
+        return
       }
 
-      initial && !initial.reserve && execute(initial)
-      options.shared.retries = retries = 0
-      initial = null
+      // If there is a pending types request, trigger the execution after it's complete
+      (typesPromise || Promise.resolve()).then(() => {
+        initial && !initial.reserve && execute(initial)
+        options.shared.retries = retries = 0
+        initial = null
+      })
       return
     }
 


### PR DESCRIPTION
This PR fixes #789 by storing the array types request for potential promise chaining, if a query occurs before the types have finished being retrieved.

As described by #789, queries which use `sql.array()` can fail if they use a fresh connection. This can be seen in the "Array of Date" test within this repository, if the test is run by itself (using `ot()`).

After some investigation/debugging, it looks like there is a race condition between the completion of the `fetchArrayTypes` method, and the scheduling of the subsequent query. In my debugger, I was able to see the call to `execute` proceed far enough that the `typeArrayMap` was not updated before the query types were processed. Shortly after this, the `fetchArrayTypes` method completed and updated the `typeArrayMap`, but it was already too late.

The reason the "Array of Date" test doesn't fail as part of the test suite is because the types are initialized by the other tests that run before it. This is a timing sensitive issue, and if a test that does not use array types runs first then the types get initialized without any problems.

Please note I've run `npm build` and included the generated code as part of this PR. I'm not sure if that is the recommended approach to PRs for this project, or if the generated code will be built as part of the release process. I'm happy to amend the change set if necessary. I couldn't find a `CONTRIBUTING.md` file or contributor instructions anywhere but it's possible I missed them.