### PR TITLE
Direct TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,7 +987,7 @@ const sql = postgres('postgres://username:password@host:port/database', {
   database             : '',            // Name of database to connect to
   username             : '',            // Username of database user
   password             : '',            // Password of database user
-  ssl                  : false,         // true, prefer, require, tls.connect options
+  ssl                  : false,         // true, prefer, require, direct, tls.connect options
   max                  : 10,            // Max number of connections
   max_lifetime         : null,          // Max lifetime in seconds (more info below)
   idle_timeout         : 0,             // Idle connection timeout in seconds

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -44,7 +44,7 @@ interface BaseOptions<T extends Record<string, postgres.PostgresType>> {
    * How to deal with ssl (can be a tls.connect option object)
    * @default false
   */
-  ssl: 'require' | 'allow' | 'prefer' | 'verify-full' | boolean | object;
+  ssl: 'require' | 'allow' | 'prefer' | 'verify-full' | 'direct' | boolean | object;
   /**
    * Max number of connections
    * @default 10


### PR DESCRIPTION
Added support for "direct TLS" introduced in Postgres 17+ ([changelog](https://www.postgresql.org/docs/release/17.0/)).

To connect with the new mode use: `ssl: 'direct'`.

This connection mode is recommended for use with AWS Aurora DSQL ([blog post](https://marc-bowes.com/postgres-direct-tls.html)).