### PR TITLE
reset rows count before executing new queries on a connection 

### DIFF
--- a/cf/src/connection.js
+++ b/cf/src/connection.js
@@ -528,6 +528,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   function ReadyForQuery(x) {
     query && query.options.simple && query.resolve(results || result)
     query = results = null
+    rows = 0
     result = new Result()
     connectTimer.cancel()
 

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -526,6 +526,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   function ReadyForQuery(x) {
     query && query.options.simple && query.resolve(results || result)
     query = results = null
+    rows = 0
     result = new Result()
     connectTimer.cancel()
 

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -2614,3 +2614,22 @@ t('Ensure reserve on query throws proper error', async() => {
     'wat', x, reserved.release()
   ]
 })
+
+t('Ensure rows count is cleared before performing new query on a connection', async() => {
+  const sql = postgres({ idle_timeout, max: 1 }) // eslint-disable-line
+  await sql`create table table_causing_error(name text,age int)`
+  await sql`insert into table_causing_error values('John', 20)`
+  await sql`insert into table_causing_error values('Jane', 21)`
+  await sql`insert into table_causing_error values('Jim', 0)`
+
+  await sql`create table some_other_table(title text,amount int)`
+  await sql`insert into some_other_table values ('a', 100), ('b', 200), ('c', 300), ('d', 400), ('e', 500), ('f', 600)`
+
+  const rows_count_before_error = await sql`select * from some_other_table`
+  await sql`select * from table_causing_error where 1000/age > 0`.catch(e => e)
+  const rows_count_after_error = await sql`select * from some_other_table`
+
+  return [
+    rows_count_before_error, rows_count_after_error
+  ]
+})

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -529,6 +529,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   function ReadyForQuery(x) {
     query && query.options.simple && query.resolve(results || result)
     query = results = null
+    rows = 0
     result = new Result()
     connectTimer.cancel()
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -526,6 +526,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   function ReadyForQuery(x) {
     query && query.options.simple && query.resolve(results || result)
     query = results = null
+    rows = 0
     result = new Result()
     connectTimer.cancel()
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -2614,3 +2614,25 @@ t('Ensure reserve on query throws proper error', async() => {
     'wat', x, reserved.release()
   ]
 })
+
+t('Ensure rows count is cleared before performing new query on a connection', async() => {
+  const sql = postgres({ idle_timeout, max: 1 }) // eslint-disable-line
+  await sql`create table table_causing_error(name text,age int)`
+  await sql`insert into table_causing_error values('John', 20)`
+  await sql`insert into table_causing_error values('Jane', 21)`
+  await sql`insert into table_causing_error values('Jim', 0)`
+
+  await sql`create table some_other_table(title text,amount int)`
+  await sql`insert into some_other_table values ('a', 100), ('b', 200), ('c', 300), ('d', 400), ('e', 500), ('f', 600)`
+
+  const rows_count_before_error = await sql`select * from some_other_table`
+  await sql`select * from table_causing_error where 1000/age > 0`.catch(e => e)
+  const rows_count_after_error = await sql`select * from some_other_table`
+
+  await sql`drop table table_causing_error`
+  await sql`drop table some_other_table`
+
+  return [
+    rows_count_before_error.length, rows_count_after_error.length
+  ]
+})


### PR DESCRIPTION
this PR attempts to fix issue #1119 

Currently the rows count is only set to 0 in the `CommandComplete` handler, but in case of an error this handler isn't called, so we changed this to be on the query prepare handler which is called any time a query starts execution