### PR TITLE
omit Sql properties absent from TransactionSql in type definition 

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -715,7 +715,20 @@ declare namespace postgres {
     prepare?: boolean | undefined;
   }
 
-  interface TransactionSql<TTypes extends Record<string, unknown> = {}> extends Sql<TTypes> {
+  interface TransactionSql<TTypes extends Record<string, unknown> = {}> extends Omit<Sql<TTypes>,
+      'parameters' |
+      'largeObject' |
+      'subscribe' |
+      'CLOSE' |
+      'END' |
+      'PostgresError' |
+      'options' |
+      'reserve' |
+      'listen' |
+      'begin' |
+      'close' |
+      'end'
+  > {
     savepoint<T>(cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
     savepoint<T>(name: string, cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
 


### PR DESCRIPTION
TransactionSql is missing properties from Sql added in https://github.com/porsager/postgres/blob/32feb259a3c9abffab761bd1758b3168d9e0cebc/src/index.js#L69-L82.

This PR updates the type definition of TransactionSql to reflect this.

This means typescript will now raise an error if consuming code tries the following:

```ts
sql.begin((trx) => {
   trx.begin((trx2) => {
       ...
   })
})

```
