### PR TITLE
fix: end() hangs forever after ECONNRESET error

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -388,7 +388,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
   function errored(err) {
     stream && (stream.destroy(err), stream = null)
-    query && queryError(query, err)
+    query && (queryError(query, err), query = null)
     initial && (queryError(initial, err), initial = null)
   }
 
@@ -449,7 +449,14 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     if (initial)
       return reconnect()
 
-    !hadError && (query || sent.length) && error(Errors.connection('CONNECTION_CLOSED', options, socket))
+    if (hadError) {
+      // Clear query when connection closes with error (e.g., ECONNRESET)
+      query && (queryError(query, Errors.connection('CONNECTION_CLOSED', options, socket)), query = null)
+      while (sent.length)
+        queryError(sent.shift(), Errors.connection('CONNECTION_CLOSED', options, socket))
+    } else {
+      (query || sent.length) && error(Errors.connection('CONNECTION_CLOSED', options, socket))
+    }
     closedTime = performance.now()
     hadError && options.shared.retries++
     delay = (typeof backoff === 'function' ? backoff(options.shared.retries) : backoff) * 1000

--- a/tests/index.js
+++ b/tests/index.js
@@ -2638,3 +2638,42 @@ t('query during copy error', async() => {
     await sql`drop table test`
   ]
 })
+
+t('end() completes after ECONNRESET error', { timeout: 5 }, async() => {
+  // Create a real connection, then terminate the backend to simulate ECONNRESET
+  const sql = postgres({ ...options, max: 1 })
+  const sql2 = postgres({ ...options, max: 1 })
+  
+  // Get the connection's backend PID
+  const [{ pid }] = await sql`select pg_backend_pid() as pid`
+  
+  // Start a query and immediately terminate the backend connection
+  const queryPromise = sql.unsafe('SELECT pg_sleep(1)').catch(e => e)
+  
+  // Terminate the backend right after query starts using a different connection
+  await delay(10)
+  await sql2`select pg_terminate_backend(${ pid })`
+  
+  // Wait for the query to fail with ECONNRESET
+  const error = await queryPromise
+  
+  // Verify we got a connection error (57P01 = terminating connection, ECONNRESET, or CONNECTION_CLOSED)
+  if (!error || (error.code !== 'ECONNRESET' && error.code !== 'CONNECTION_CLOSED' && error.code !== '57P01' && !error.message.includes('terminated'))) {
+    await sql.end()
+    await sql2.end()
+    throw new Error('Expected connection error, got: ' + (error ? (error.code || error.message) : 'no error'))
+  }
+  
+  // Now try to end the connection - this should complete, not hang
+  const endStart = Date.now()
+  await sql.end()
+  const endDuration = Date.now() - endStart
+  
+  await sql2.end()
+  
+  // end() should complete quickly (within 1 second), not hang forever
+  return [
+    true,
+    endDuration < 1000
+  ]
+})


### PR DESCRIPTION
## Problem

When a query fails with `ECONNRESET` (or any connection error), calling `pg.end()` hangs forever. This happens because:

1. When a connection error occurs, the `query` variable in the connection is never cleared
2. In the normal path, `ReadyForQuery` clears `query = null`, but connection errors never reach that handler
3. When `end()` is called, it checks `!query` to determine if it can terminate immediately
4. Since `query` still references the rejected query object, the condition fails and `end()` creates a promise waiting for `ended` to be called
5. However, `ended` is only called in `terminate()`, which is only called when `!query` is true - creating a deadlock

## Solution

I've made two changes to ensure the `query` variable is properly cleared when connection errors occur:

1. **In `errored()` function**: Clear `query = null` after rejecting the query
2. **In `closed()` function**: When `hadError` is true, clear the query before closing (since `errored()` might not always be called in all error paths)

## Changes

- `src/connection.js`: 
  - Modified `errored()` to clear `query` after `queryError()`
  - Modified `closed()` to clear `query` when `hadError` is true
- `tests/index.js`: Added test `'end() completes after ECONNRESET error'` to verify the fix

## Testing

The new test creates a real PostgreSQL connection, terminates the backend during a query execution, and verifies that `end()` completes quickly (within 1 second) instead of hanging forever.

## Notes

I'm not entirely sure if this is the best approach - I spent a significant amount of time understanding the codebase and the problem. The connection lifecycle and query state management is quite complex, and I wanted to make sure I understood the flow before making changes. I also received help from AI to better understand the problem and explore the codebase, which was invaluable in identifying where the `query` variable needed to be cleared.

I'm open to feedback and alternative approaches if there's a better way to handle this!

Fixes #1130