### PR TITLE
Improve behaviour of idle_in_transaction_session_timeout

### DIFF
--- a/cf/src/connection.js
+++ b/cf/src/connection.js
@@ -254,6 +254,11 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   function nextWrite(fn) {
+    if (!socket) {
+      // Connection was closed, cannot write
+      chunk = nextWriteTimer = null
+      return false
+    }
     const x = socket.write(chunk, fn)
     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
     chunk = nextWriteTimer = null
@@ -436,6 +441,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   async function closed(hadError) {
+    terminated = true  // Mark connection as terminated to prevent further query attempts
     incoming = Buffer.alloc(0)
     remaining = 0
     incomings = null

--- a/cf/src/index.js
+++ b/cf/src/index.js
@@ -238,12 +238,13 @@ function Postgres(a, b) {
     let savepoints = 0
       , connection
       , prepare = null
+      , closed = false
 
     try {
       await sql.unsafe('begin ' + options.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
       return await Promise.race([
         scope(connection, fn),
-        new Promise((_, reject) => connection.onclose = reject)
+        new Promise((_, reject) => connection.onclose = e => (closed = true, reject(e)))
       ])
     } catch (error) {
       throw error
@@ -290,6 +291,8 @@ function Postgres(a, b) {
       }
 
       function handler(q) {
+        if (closed)
+          return q.reject(Errors.connection('CONNECTION_CLOSED', options))
         q.catch(e => uncaughtError || (uncaughtError = e))
         c.queue === full
           ? queries.push(q)

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -252,6 +252,11 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   function nextWrite(fn) {
+    if (!socket) {
+      // Connection was closed, cannot write
+      chunk = nextWriteTimer = null
+      return false
+    }
     const x = socket.write(chunk, fn)
     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
     chunk = nextWriteTimer = null
@@ -434,6 +439,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   async function closed(hadError) {
+    terminated = true  // Mark connection as terminated to prevent further query attempts
     incoming = Buffer.alloc(0)
     remaining = 0
     incomings = null

--- a/cjs/src/index.js
+++ b/cjs/src/index.js
@@ -237,12 +237,13 @@ function Postgres(a, b) {
     let savepoints = 0
       , connection
       , prepare = null
+      , closed = false
 
     try {
       await sql.unsafe('begin ' + options.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
       return await Promise.race([
         scope(connection, fn),
-        new Promise((_, reject) => connection.onclose = reject)
+        new Promise((_, reject) => connection.onclose = e => (closed = true, reject(e)))
       ])
     } catch (error) {
       throw error
@@ -289,6 +290,8 @@ function Postgres(a, b) {
       }
 
       function handler(q) {
+        if (closed)
+          return q.reject(Errors.connection('CONNECTION_CLOSED', options))
         q.catch(e => uncaughtError || (uncaughtError = e))
         c.queue === full
           ? queries.push(q)

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -2638,3 +2638,49 @@ t('query during copy error', async() => {
     await sql`drop table test`
   ]
 })
+
+t('idle_in_transaction_session_timeout causes CONNECTION_CLOSED', { timeout: 5 }, async() => {
+  const sql = postgres(options)
+  const error = await sql.begin(async(txSql) => {
+    await txSql`SET LOCAL idle_in_transaction_session_timeout = '1s'`
+    await new Promise(r => setTimeout(r, 2000))
+    await txSql`SELECT 1`
+  }).catch(e => e)
+  await sql.end()
+  return [true, error.code === 'CONNECTION_CLOSED' || error.code === 'CONNECTION_DESTROYED']
+})
+
+t('txSql fails after idle_in_transaction_session_timeout even if callback continues', { timeout: 5 }, async() => {
+  const sql = postgres(options)
+  let failed = false
+  await sql.begin(async(txSql) => {
+    await txSql`SET LOCAL idle_in_transaction_session_timeout = '1s'`
+    await new Promise(r => setTimeout(r, 2000))
+    try { await txSql`SELECT 1` } catch (e) {
+      failed = e.code === 'CONNECTION_CLOSED' || e.code === 'CONNECTION_DESTROYED'
+    }
+  }).catch(() => { /* ignore */ })
+  await new Promise(r => setTimeout(r, 1000))
+  await sql.end()
+  return [true, failed]
+})
+
+t('txSql fails even when pool connection reconnects after idle timeout', { timeout: 10 }, async() => {
+  const sql = postgres({ ...options, max: 1 })
+  // Queue pool queries to trigger reconnect after connection closes
+  for (let i = 0; i < 3; i++)
+    setTimeout(() => sql`SELECT ${i}`.catch(() => { /* ignore */ }), 1000 + i * 100)
+
+  let txSqlSucceeded = false
+  await sql.begin(async(txSql) => {
+    await txSql`SET LOCAL idle_in_transaction_session_timeout = '1s'`
+    await new Promise(r => setTimeout(r, 2000))
+    try {
+      await txSql`SELECT 'should fail'`
+      txSqlSucceeded = true
+    } catch { /* ignore */ }
+  }).catch(() => { /* ignore */ })
+  await new Promise(r => setTimeout(r, 1000))
+  await sql.end()
+  return [false, txSqlSucceeded]
+})

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -255,6 +255,11 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   function nextWrite(fn) {
+    if (!socket) {
+      // Connection was closed, cannot write
+      chunk = nextWriteTimer = null
+      return false
+    }
     const x = socket.write(chunk, fn)
     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
     chunk = nextWriteTimer = null
@@ -437,6 +442,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   async function closed(hadError) {
+    terminated = true  // Mark connection as terminated to prevent further query attempts
     incoming = Buffer.alloc(0)
     remaining = 0
     incomings = null

--- a/deno/src/index.js
+++ b/deno/src/index.js
@@ -238,12 +238,13 @@ function Postgres(a, b) {
     let savepoints = 0
       , connection
       , prepare = null
+      , closed = false
 
     try {
       await sql.unsafe('begin ' + options.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
       return await Promise.race([
         scope(connection, fn),
-        new Promise((_, reject) => connection.onclose = reject)
+        new Promise((_, reject) => connection.onclose = e => (closed = true, reject(e)))
       ])
     } catch (error) {
       throw error
@@ -290,6 +291,8 @@ function Postgres(a, b) {
       }
 
       function handler(q) {
+        if (closed)
+          return q.reject(Errors.connection('CONNECTION_CLOSED', options))
         q.catch(e => uncaughtError || (uncaughtError = e))
         c.queue === full
           ? queries.push(q)

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -2641,4 +2641,50 @@ t('query during copy error', async() => {
   ]
 })
 
+t('idle_in_transaction_session_timeout causes CONNECTION_CLOSED', { timeout: 5 }, async() => {
+  const sql = postgres(options)
+  const error = await sql.begin(async(txSql) => {
+    await txSql`SET LOCAL idle_in_transaction_session_timeout = '1s'`
+    await new Promise(r => setTimeout(r, 2000))
+    await txSql`SELECT 1`
+  }).catch(e => e)
+  await sql.end()
+  return [true, error.code === 'CONNECTION_CLOSED' || error.code === 'CONNECTION_DESTROYED']
+})
+
+t('txSql fails after idle_in_transaction_session_timeout even if callback continues', { timeout: 5 }, async() => {
+  const sql = postgres(options)
+  let failed = false
+  await sql.begin(async(txSql) => {
+    await txSql`SET LOCAL idle_in_transaction_session_timeout = '1s'`
+    await new Promise(r => setTimeout(r, 2000))
+    try { await txSql`SELECT 1` } catch (e) {
+      failed = e.code === 'CONNECTION_CLOSED' || e.code === 'CONNECTION_DESTROYED'
+    }
+  }).catch(() => { /* ignore */ })
+  await new Promise(r => setTimeout(r, 1000))
+  await sql.end()
+  return [true, failed]
+})
+
+t('txSql fails even when pool connection reconnects after idle timeout', { timeout: 10 }, async() => {
+  const sql = postgres({ ...options, max: 1 })
+  // Queue pool queries to trigger reconnect after connection closes
+  for (let i = 0; i < 3; i++)
+    setTimeout(() => sql`SELECT ${i}`.catch(() => { /* ignore */ }), 1000 + i * 100)
+
+  let txSqlSucceeded = false
+  await sql.begin(async(txSql) => {
+    await txSql`SET LOCAL idle_in_transaction_session_timeout = '1s'`
+    await new Promise(r => setTimeout(r, 2000))
+    try {
+      await txSql`SELECT 'should fail'`
+      txSqlSucceeded = true
+    } catch { /* ignore */ }
+  }).catch(() => { /* ignore */ })
+  await new Promise(r => setTimeout(r, 1000))
+  await sql.end()
+  return [false, txSqlSucceeded]
+})
+
 ;globalThis.addEventListener("unload", () => Deno.exit(process.exitCode))

--- a/src/connection.js
+++ b/src/connection.js
@@ -252,6 +252,11 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   function nextWrite(fn) {
+    if (!socket) {
+      // Connection was closed, cannot write
+      chunk = nextWriteTimer = null
+      return false
+    }
     const x = socket.write(chunk, fn)
     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
     chunk = nextWriteTimer = null
@@ -434,6 +439,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   async function closed(hadError) {
+    terminated = true  // Mark connection as terminated to prevent further query attempts
     incoming = Buffer.alloc(0)
     remaining = 0
     incomings = null

--- a/src/index.js
+++ b/src/index.js
@@ -237,12 +237,13 @@ function Postgres(a, b) {
     let savepoints = 0
       , connection
       , prepare = null
+      , closed = false
 
     try {
       await sql.unsafe('begin ' + options.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
       return await Promise.race([
         scope(connection, fn),
-        new Promise((_, reject) => connection.onclose = reject)
+        new Promise((_, reject) => connection.onclose = e => (closed = true, reject(e)))
       ])
     } catch (error) {
       throw error
@@ -289,6 +290,8 @@ function Postgres(a, b) {
       }
 
       function handler(q) {
+        if (closed)
+          return q.reject(Errors.connection('CONNECTION_CLOSED', options))
         q.catch(e => uncaughtError || (uncaughtError = e))
         c.queue === full
           ? queries.push(q)

--- a/tests/index.js
+++ b/tests/index.js
@@ -2638,3 +2638,49 @@ t('query during copy error', async() => {
     await sql`drop table test`
   ]
 })
+
+t('idle_in_transaction_session_timeout causes CONNECTION_CLOSED', { timeout: 5 }, async() => {
+  const sql = postgres(options)
+  const error = await sql.begin(async(txSql) => {
+    await txSql`SET LOCAL idle_in_transaction_session_timeout = '1s'`
+    await new Promise(r => setTimeout(r, 2000))
+    await txSql`SELECT 1`
+  }).catch(e => e)
+  await sql.end()
+  return [true, error.code === 'CONNECTION_CLOSED' || error.code === 'CONNECTION_DESTROYED']
+})
+
+t('txSql fails after idle_in_transaction_session_timeout even if callback continues', { timeout: 5 }, async() => {
+  const sql = postgres(options)
+  let failed = false
+  await sql.begin(async(txSql) => {
+    await txSql`SET LOCAL idle_in_transaction_session_timeout = '1s'`
+    await new Promise(r => setTimeout(r, 2000))
+    try { await txSql`SELECT 1` } catch (e) {
+      failed = e.code === 'CONNECTION_CLOSED' || e.code === 'CONNECTION_DESTROYED'
+    }
+  }).catch(() => { /* ignore */ })
+  await new Promise(r => setTimeout(r, 1000))
+  await sql.end()
+  return [true, failed]
+})
+
+t('txSql fails even when pool connection reconnects after idle timeout', { timeout: 10 }, async() => {
+  const sql = postgres({ ...options, max: 1 })
+  // Queue pool queries to trigger reconnect after connection closes
+  for (let i = 0; i < 3; i++)
+    setTimeout(() => sql`SELECT ${i}`.catch(() => { /* ignore */ }), 1000 + i * 100)
+
+  let txSqlSucceeded = false
+  await sql.begin(async(txSql) => {
+    await txSql`SET LOCAL idle_in_transaction_session_timeout = '1s'`
+    await new Promise(r => setTimeout(r, 2000))
+    try {
+      await txSql`SELECT 'should fail'`
+      txSqlSucceeded = true
+    } catch { /* ignore */ }
+  }).catch(() => { /* ignore */ })
+  await new Promise(r => setTimeout(r, 1000))
+  await sql.end()
+  return [false, txSqlSucceeded]
+})


### PR DESCRIPTION
Related to #1133

When PostgreSQL kills a connection due to idle_in_transaction_session_timeout, two issues could occur:

  1. Uncatchable crash: nextWrite() attempted to write to a null socket
  2. Silent execution outside transaction!!: If pool had pending queries, the connection would reconnect and subsequent txSql queries could execute on the new connection—outside of the intended transaction context—causing potential data corruption

Changes:

src/connection.js:
  - Set terminated = true in closed() before nulling socket
  - Add null guard in nextWrite() to prevent crash

src/index.js:
  - Track closed state in begin() scope
  - Reject txSql queries immediately if connection was closed, preventing execution after reconnect

This ensures txSql always fails with CONNECTION_CLOSED when the underlying connection is killed, regardless of whether the connection object later reconnects for other pool queries.