### PR TITLE
Support named types

### DIFF
--- a/cf/src/connection.js
+++ b/cf/src/connection.js
@@ -563,7 +563,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       if (needsTypes) {
         initial.reserve && (initial = null)
-        return fetchArrayTypes()
+        return fetchTypes()
       }
 
       initial && !initial.reserve && execute(initial)
@@ -659,7 +659,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         name: transform.column.from
           ? transform.column.from(x.toString('utf8', start, index - 1))
           : x.toString('utf8', start, index - 1),
-        parser: parsers[type],
+        parser: parsers[type] || parsers[options.shared.typeOidToName[type]],
         table,
         number,
         type
@@ -767,26 +767,29 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     backend.secret = x.readUInt32BE(9)
   }
 
-  async function fetchArrayTypes() {
+  async function fetchTypes() {
     needsTypes = false
     const types = await new Query([`
-      select b.oid, b.typarray
-      from pg_catalog.pg_type a
-      left join pg_catalog.pg_type b on b.oid = a.typelem
-      where a.typcategory = 'A'
-      group by b.oid, b.typarray
-      order by b.oid
+      select oid, typname, typarray
+      from pg_catalog.pg_type
+      order by oid
     `], [], execute)
-    types.forEach(({ oid, typarray }) => addArrayType(oid, typarray))
+    types.forEach(({ oid, typname, typarray }) => {
+      options.shared.typeNameToOid[typname] = oid
+      options.shared.typeOidToName[oid] = typname
+
+      if (typarray) addArrayType(oid, typarray)
+    })
   }
 
   function addArrayType(oid, typarray) {
     if (!!options.parsers[typarray] && !!options.serializers[typarray]) return
-    const parser = options.parsers[oid]
+    const name = options.shared.typeOidToName[oid]
+    const parser = options.parsers[oid] || options.parsers[name]
     options.shared.typeArrayMap[oid] = typarray
     options.parsers[typarray] = (xs) => arrayParser(xs, parser, typarray)
     options.parsers[typarray].array = true
-    options.serializers[typarray] = (xs) => arraySerializer(xs, options.serializers[oid], options, typarray)
+    options.serializers[typarray] = (xs) => arraySerializer(xs, options.serializers[oid] || options.serializers[name], options, typarray)
   }
 
   function tryNext(x, xs) {
@@ -973,7 +976,10 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
   function Parse(str, parameters, types, name = '') {
     b().P().str(name + b.N).str(str + b.N).i16(parameters.length)
-    parameters.forEach((x, i) => b.i32(types[i] || 0))
+    parameters.forEach((x, i) => {
+      const type = types[i]
+      b.i32(options.shared.typeNameToOid[type] || type || 0)
+    })
     return b.end()
   }
 

--- a/cf/src/index.js
+++ b/cf/src/index.js
@@ -496,7 +496,7 @@ function parseOptions(a, b) {
     socket          : o.socket,
     transform       : parseTransform(o.transform || { undefined: undefined }),
     parameters      : {},
-    shared          : { retries: 0, typeArrayMap: {} },
+    shared          : { retries: 0, typeArrayMap: {}, typeNameToOid: {}, typeOidToName: {} },
     ...mergeUserTypes(o.types)
   }
 }

--- a/cf/src/types.js
+++ b/cf/src/types.js
@@ -87,7 +87,7 @@ export function handleValue(x, parameters, types, options) {
   return '$' + (types.push(
     x instanceof Parameter
       ? (parameters.push(x.value), x.array
-        ? x.array[x.type || inferType(x.value)] || x.type || firstIsString(x.value)
+        ? x.array[options.shared.typeNameToOid[x.type] || x.type || inferType(x.value)] || x.type || firstIsString(x.value)
         : x.type
       )
       : (parameters.push(x), inferType(x))

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -561,7 +561,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       if (needsTypes) {
         initial.reserve && (initial = null)
-        return fetchArrayTypes()
+        return fetchTypes()
       }
 
       initial && !initial.reserve && execute(initial)
@@ -657,7 +657,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         name: transform.column.from
           ? transform.column.from(x.toString('utf8', start, index - 1))
           : x.toString('utf8', start, index - 1),
-        parser: parsers[type],
+        parser: parsers[type] || parsers[options.shared.typeOidToName[type]],
         table,
         number,
         type
@@ -765,26 +765,29 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     backend.secret = x.readUInt32BE(9)
   }
 
-  async function fetchArrayTypes() {
+  async function fetchTypes() {
     needsTypes = false
     const types = await new Query([`
-      select b.oid, b.typarray
-      from pg_catalog.pg_type a
-      left join pg_catalog.pg_type b on b.oid = a.typelem
-      where a.typcategory = 'A'
-      group by b.oid, b.typarray
-      order by b.oid
+      select oid, typname, typarray
+      from pg_catalog.pg_type
+      order by oid
     `], [], execute)
-    types.forEach(({ oid, typarray }) => addArrayType(oid, typarray))
+    types.forEach(({ oid, typname, typarray }) => {
+      options.shared.typeNameToOid[typname] = oid
+      options.shared.typeOidToName[oid] = typname
+
+      if (typarray) addArrayType(oid, typarray)
+    })
   }
 
   function addArrayType(oid, typarray) {
     if (!!options.parsers[typarray] && !!options.serializers[typarray]) return
-    const parser = options.parsers[oid]
+    const name = options.shared.typeOidToName[oid]
+    const parser = options.parsers[oid] || options.parsers[name]
     options.shared.typeArrayMap[oid] = typarray
     options.parsers[typarray] = (xs) => arrayParser(xs, parser, typarray)
     options.parsers[typarray].array = true
-    options.serializers[typarray] = (xs) => arraySerializer(xs, options.serializers[oid], options, typarray)
+    options.serializers[typarray] = (xs) => arraySerializer(xs, options.serializers[oid] || options.serializers[name], options, typarray)
   }
 
   function tryNext(x, xs) {
@@ -971,7 +974,10 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
   function Parse(str, parameters, types, name = '') {
     b().P().str(name + b.N).str(str + b.N).i16(parameters.length)
-    parameters.forEach((x, i) => b.i32(types[i] || 0))
+    parameters.forEach((x, i) => {
+      const type = types[i]
+      b.i32(options.shared.typeNameToOid[type] || type || 0)
+    })
     return b.end()
   }
 

--- a/cjs/src/index.js
+++ b/cjs/src/index.js
@@ -495,7 +495,7 @@ function parseOptions(a, b) {
     socket          : o.socket,
     transform       : parseTransform(o.transform || { undefined: undefined }),
     parameters      : {},
-    shared          : { retries: 0, typeArrayMap: {} },
+    shared          : { retries: 0, typeArrayMap: {}, typeNameToOid: {}, typeOidToName: {} },
     ...mergeUserTypes(o.types)
   }
 }

--- a/cjs/src/types.js
+++ b/cjs/src/types.js
@@ -86,7 +86,7 @@ module.exports.handleValue = handleValue;function handleValue(x, parameters, typ
   return '$' + (types.push(
     x instanceof Parameter
       ? (parameters.push(x.value), x.array
-        ? x.array[x.type || inferType(x.value)] || x.type || firstIsString(x.value)
+        ? x.array[options.shared.typeNameToOid[x.type] || x.type || inferType(x.value)] || x.type || firstIsString(x.value)
         : x.type
       )
       : (parameters.push(x), inferType(x))

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -539,6 +539,24 @@ t('Point type array', async() => {
   return [30, (await sql`select x from test`)[0].x[1][1], await sql`drop table test`]
 })
 
+t('Point type with named OIDs', async() => {
+  const sql = postgres({
+    ...options,
+    types: {
+      point: {
+        to: 'point',
+        from: ['point'],
+        serialize: ([x, y]) => '(' + x + ',' + y + ')',
+        parse: (x) => x.slice(1, -1).split(',').map(x => +x)
+      }
+    }
+  })
+
+  await sql`create table test (x point)`
+  await sql`insert into test (x) values (${ sql.types.point([10, 20]) })`
+  return [20, (await sql`select x from test`)[0].x[1], await sql`drop table test`]
+})
+
 t('sql file', async() =>
   [1, (await sql.file(rel('select.sql')))[0].x]
 )

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -564,7 +564,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       if (needsTypes) {
         initial.reserve && (initial = null)
-        return fetchArrayTypes()
+        return fetchTypes()
       }
 
       initial && !initial.reserve && execute(initial)
@@ -660,7 +660,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         name: transform.column.from
           ? transform.column.from(x.toString('utf8', start, index - 1))
           : x.toString('utf8', start, index - 1),
-        parser: parsers[type],
+        parser: parsers[type] || parsers[options.shared.typeOidToName[type]],
         table,
         number,
         type
@@ -768,26 +768,29 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     backend.secret = x.readUInt32BE(9)
   }
 
-  async function fetchArrayTypes() {
+  async function fetchTypes() {
     needsTypes = false
     const types = await new Query([`
-      select b.oid, b.typarray
-      from pg_catalog.pg_type a
-      left join pg_catalog.pg_type b on b.oid = a.typelem
-      where a.typcategory = 'A'
-      group by b.oid, b.typarray
-      order by b.oid
+      select oid, typname, typarray
+      from pg_catalog.pg_type
+      order by oid
     `], [], execute)
-    types.forEach(({ oid, typarray }) => addArrayType(oid, typarray))
+    types.forEach(({ oid, typname, typarray }) => {
+      options.shared.typeNameToOid[typname] = oid
+      options.shared.typeOidToName[oid] = typname
+
+      if (typarray) addArrayType(oid, typarray)
+    })
   }
 
   function addArrayType(oid, typarray) {
     if (!!options.parsers[typarray] && !!options.serializers[typarray]) return
-    const parser = options.parsers[oid]
+    const name = options.shared.typeOidToName[oid]
+    const parser = options.parsers[oid] || options.parsers[name]
     options.shared.typeArrayMap[oid] = typarray
     options.parsers[typarray] = (xs) => arrayParser(xs, parser, typarray)
     options.parsers[typarray].array = true
-    options.serializers[typarray] = (xs) => arraySerializer(xs, options.serializers[oid], options, typarray)
+    options.serializers[typarray] = (xs) => arraySerializer(xs, options.serializers[oid] || options.serializers[name], options, typarray)
   }
 
   function tryNext(x, xs) {
@@ -974,7 +977,10 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
   function Parse(str, parameters, types, name = '') {
     b().P().str(name + b.N).str(str + b.N).i16(parameters.length)
-    parameters.forEach((x, i) => b.i32(types[i] || 0))
+    parameters.forEach((x, i) => {
+      const type = types[i]
+      b.i32(options.shared.typeNameToOid[type] || type || 0)
+    })
     return b.end()
   }
 

--- a/deno/src/index.js
+++ b/deno/src/index.js
@@ -496,7 +496,7 @@ function parseOptions(a, b) {
     socket          : o.socket,
     transform       : parseTransform(o.transform || { undefined: undefined }),
     parameters      : {},
-    shared          : { retries: 0, typeArrayMap: {} },
+    shared          : { retries: 0, typeArrayMap: {}, typeNameToOid: {}, typeOidToName: {} },
     ...mergeUserTypes(o.types)
   }
 }

--- a/deno/src/types.js
+++ b/deno/src/types.js
@@ -87,7 +87,7 @@ export function handleValue(x, parameters, types, options) {
   return '$' + (types.push(
     x instanceof Parameter
       ? (parameters.push(x.value), x.array
-        ? x.array[x.type || inferType(x.value)] || x.type || firstIsString(x.value)
+        ? x.array[options.shared.typeNameToOid[x.type] || x.type || inferType(x.value)] || x.type || firstIsString(x.value)
         : x.type
       )
       : (parameters.push(x), inferType(x))

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -541,6 +541,24 @@ t('Point type array', async() => {
   return [30, (await sql`select x from test`)[0].x[1][1], await sql`drop table test`]
 })
 
+t('Point type with named OIDs', async() => {
+  const sql = postgres({
+    ...options,
+    types: {
+      point: {
+        to: 'point',
+        from: ['point'],
+        serialize: ([x, y]) => '(' + x + ',' + y + ')',
+        parse: (x) => x.slice(1, -1).split(',').map(x => +x)
+      }
+    }
+  })
+
+  await sql`create table test (x point)`
+  await sql`insert into test (x) values (${ sql.types.point([10, 20]) })`
+  return [20, (await sql`select x from test`)[0].x[1], await sql`drop table test`]
+})
+
 t('sql file', async() =>
   [1, (await sql.file(rel('select.sql')))[0].x]
 )

--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -319,8 +319,8 @@ declare namespace postgres {
   const BigInt: PostgresType<bigint>;
 
   interface PostgresType<T = any> {
-    to: number;
-    from: number[];
+    to: (number | string);
+    from: (number | string)[];
     serialize: (value: T) => unknown;
     parse: (raw: any) => T;
   }
@@ -386,8 +386,8 @@ declare namespace postgres {
     pass: null;
     /** @inheritdoc */
     transform: Transform;
-    serializers: Record<number, (value: any) => unknown>;
-    parsers: Record<number, (value: any) => unknown>;
+    serializers: Record<number | string, (value: any) => unknown>;
+    parsers: Record<number | string, (value: any) => unknown>;
   }
 
   interface Transform {
@@ -419,9 +419,9 @@ declare namespace postgres {
 
   interface Parameter<T = SerializableParameter> extends NotAPromise {
     /**
-     * PostgreSQL OID of the type
+     * PostgreSQL OID or type name of the type
      */
-    type: number;
+    type: number | string;
     /**
      * Serialized value
      */
@@ -684,7 +684,7 @@ declare namespace postgres {
     options: ParsedOptions<TTypes>;
     parameters: ConnectionParameters;
     types: this['typed'];
-    typed: (<T>(value: T, oid: number) => Parameter<T>) & {
+    typed: (<T>(value: T, type: number | string) => Parameter<T>) & {
       [name in keyof TTypes]: (value: TTypes[name]) => postgres.Parameter<TTypes[name]>
     };
 
@@ -701,7 +701,7 @@ declare namespace postgres {
     begin<T>(cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
     begin<T>(options: string, cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
 
-    array<T extends SerializableParameter<TTypes[keyof TTypes]>[] = SerializableParameter<TTypes[keyof TTypes]>[]>(value: T, type?: number | undefined): ArrayParameter<T>;
+    array<T extends SerializableParameter<TTypes[keyof TTypes]>[] = SerializableParameter<TTypes[keyof TTypes]>[]>(value: T, type?: number | string | undefined): ArrayParameter<T>;
     file<T extends readonly any[] = Row[]>(path: string | Buffer | URL | number, options?: { cache?: boolean | undefined } | undefined): PendingQuery<T>;
     file<T extends readonly any[] = Row[]>(path: string | Buffer | URL | number, args: (ParameterOrJSON<TTypes[keyof TTypes]>)[], options?: { cache?: boolean | undefined } | undefined): PendingQuery<T>;
     json(value: JSONValue): Parameter;

--- a/src/connection.js
+++ b/src/connection.js
@@ -657,7 +657,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         name: transform.column.from
           ? transform.column.from(x.toString('utf8', start, index - 1))
           : x.toString('utf8', start, index - 1),
-        parser: parsers[type],
+        parser: parsers[type] || parsers[options.shared.typeOidToName[type]],
         table,
         number,
         type
@@ -780,11 +780,12 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
   function addArrayType(oid, typarray) {
     if (!!options.parsers[typarray] && !!options.serializers[typarray]) return
-    const parser = options.parsers[oid]
+    const name = options.shared.typeOidToName[oid]
+    const parser = options.parsers[oid] || options.parsers[name]
     options.shared.typeArrayMap[oid] = typarray
     options.parsers[typarray] = (xs) => arrayParser(xs, parser, typarray)
     options.parsers[typarray].array = true
-    options.serializers[typarray] = (xs) => arraySerializer(xs, options.serializers[oid], options, typarray)
+    options.serializers[typarray] = (xs) => arraySerializer(xs, options.serializers[oid] || options.serializers[name], options, typarray)
   }
 
   function tryNext(x, xs) {
@@ -971,7 +972,10 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
   function Parse(str, parameters, types, name = '') {
     b().P().str(name + b.N).str(str + b.N).i16(parameters.length)
-    parameters.forEach((x, i) => b.i32(types[i] || 0))
+    parameters.forEach((x, i) => {
+      const type = types[i]
+      b.i32(options.shared.typeNameToOid[type] || type || 0)
+    })
     return b.end()
   }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -561,7 +561,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       if (needsTypes) {
         initial.reserve && (initial = null)
-        return fetchArrayTypes()
+        return fetchTypes()
       }
 
       initial && !initial.reserve && execute(initial)
@@ -765,20 +765,23 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     backend.secret = x.readUInt32BE(9)
   }
 
-  async function fetchArrayTypes() {
+  async function fetchTypes() {
     needsTypes = false
     const types = await new Query([`
-      select b.oid, b.typarray
-      from pg_catalog.pg_type a
-      left join pg_catalog.pg_type b on b.oid = a.typelem
-      where a.typcategory = 'A'
-      group by b.oid, b.typarray
-      order by b.oid
+      select oid, typname, typarray
+      from pg_catalog.pg_type
+      order by oid
     `], [], execute)
-    types.forEach(({ oid, typarray }) => addArrayType(oid, typarray))
+    types.forEach(({ oid, typname }) => {
+      options.shared.typeNameToOid[typname] = oid
+      options.shared.typeOidToName[oid] = typname
+    })
+    types.forEach(({ oid, typarray }) => {
+      typarray && addType(oid, typarray)
+    })
   }
 
-  function addArrayType(oid, typarray) {
+  function addType(oid, typarray) {
     if (!!options.parsers[typarray] && !!options.serializers[typarray]) return
     const name = options.shared.typeOidToName[oid]
     const parser = options.parsers[oid] || options.parsers[name]

--- a/src/connection.js
+++ b/src/connection.js
@@ -772,16 +772,15 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       from pg_catalog.pg_type
       order by oid
     `], [], execute)
-    types.forEach(({ oid, typname }) => {
+    types.forEach(({ oid, typname, typarray }) => {
       options.shared.typeNameToOid[typname] = oid
       options.shared.typeOidToName[oid] = typname
-    })
-    types.forEach(({ oid, typarray }) => {
-      typarray && addType(oid, typarray)
+
+      if (typarray) addArrayType(oid, typarray)
     })
   }
 
-  function addType(oid, typarray) {
+  function addArrayType(oid, typarray) {
     if (!!options.parsers[typarray] && !!options.serializers[typarray]) return
     const name = options.shared.typeOidToName[oid]
     const parser = options.parsers[oid] || options.parsers[name]

--- a/src/index.js
+++ b/src/index.js
@@ -495,7 +495,7 @@ function parseOptions(a, b) {
     socket          : o.socket,
     transform       : parseTransform(o.transform || { undefined: undefined }),
     parameters      : {},
-    shared          : { retries: 0, typeArrayMap: {} },
+    shared          : { retries: 0, typeArrayMap: {}, typeNameToOid: {}, typeOidToName: {} },
     ...mergeUserTypes(o.types)
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -86,7 +86,7 @@ export function handleValue(x, parameters, types, options) {
   return '$' + (types.push(
     x instanceof Parameter
       ? (parameters.push(x.value), x.array
-        ? x.array[x.type || inferType(x.value)] || x.type || firstIsString(x.value)
+        ? x.array[options.shared.typeNameToOid[x.type] || x.type || inferType(x.value)] || x.type || firstIsString(x.value)
         : x.type
       )
       : (parameters.push(x), inferType(x))

--- a/tests/index.js
+++ b/tests/index.js
@@ -539,6 +539,27 @@ t('Point type array', async() => {
   return [30, (await sql`select x from test`)[0].x[1][1], await sql`drop table test`]
 })
 
+t('Point type with named OIDs', async() => {
+  const sql = postgres({
+    ...options,
+    types: {
+      point: {
+        to: 'point',
+        from: ['point'],
+        serialize: ([x, y]) => '(' + x + ',' + y + ')',
+        parse: (x) => x.slice(1, -1).split(',').map(x => +x)
+      }
+    }
+  })
+
+  sql.options.shared.typeNameToOid['point'] = 600
+  sql.options.shared.typeOidToName[600] = 'point'
+
+  await sql`create table test (x point)`
+  await sql`insert into test (x) values (${ sql.types.point([10, 20]) })`
+  return [20, (await sql`select x from test`)[0].x[1], await sql`drop table test`]
+})
+
 t('sql file', async() =>
   [1, (await sql.file(rel('select.sql')))[0].x]
 )

--- a/tests/index.js
+++ b/tests/index.js
@@ -552,9 +552,6 @@ t('Point type with named OIDs', async() => {
     }
   })
 
-  sql.options.shared.typeNameToOid['point'] = 600
-  sql.options.shared.typeOidToName[600] = 'point'
-
   await sql`create table test (x point)`
   await sql`insert into test (x) values (${ sql.types.point([10, 20]) })`
   return [20, (await sql`select x from test`)[0].x[1], await sql`drop table test`]

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -317,8 +317,8 @@ declare namespace postgres {
   const BigInt: PostgresType<bigint>;
 
   interface PostgresType<T = any> {
-    to: number;
-    from: number[];
+    to: (number | string);
+    from: (number | string)[];
     serialize: (value: T) => unknown;
     parse: (raw: any) => T;
   }
@@ -384,8 +384,8 @@ declare namespace postgres {
     pass: null;
     /** @inheritdoc */
     transform: Transform;
-    serializers: Record<number, (value: any) => unknown>;
-    parsers: Record<number, (value: any) => unknown>;
+    serializers: Record<number | string, (value: any) => unknown>;
+    parsers: Record<number | string, (value: any) => unknown>;
   }
 
   interface Transform {
@@ -417,9 +417,9 @@ declare namespace postgres {
 
   interface Parameter<T = SerializableParameter> extends NotAPromise {
     /**
-     * PostgreSQL OID of the type
+     * PostgreSQL OID or type name of the type
      */
-    type: number;
+    type: number | string;
     /**
      * Serialized value
      */
@@ -682,7 +682,7 @@ declare namespace postgres {
     options: ParsedOptions<TTypes>;
     parameters: ConnectionParameters;
     types: this['typed'];
-    typed: (<T>(value: T, oid: number) => Parameter<T>) & {
+    typed: (<T>(value: T, type: number | string) => Parameter<T>) & {
       [name in keyof TTypes]: (value: TTypes[name]) => postgres.Parameter<TTypes[name]>
     };
 
@@ -699,7 +699,7 @@ declare namespace postgres {
     begin<T>(cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
     begin<T>(options: string, cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
 
-    array<T extends SerializableParameter<TTypes[keyof TTypes]>[] = SerializableParameter<TTypes[keyof TTypes]>[]>(value: T, type?: number | undefined): ArrayParameter<T>;
+    array<T extends SerializableParameter<TTypes[keyof TTypes]>[] = SerializableParameter<TTypes[keyof TTypes]>[]>(value: T, type?: number | string | undefined): ArrayParameter<T>;
     file<T extends readonly any[] = Row[]>(path: string | Buffer | URL | number, options?: { cache?: boolean | undefined } | undefined): PendingQuery<T>;
     file<T extends readonly any[] = Row[]>(path: string | Buffer | URL | number, args: (ParameterOrJSON<TTypes[keyof TTypes]>)[], options?: { cache?: boolean | undefined } | undefined): PendingQuery<T>;
     json(value: JSONValue): Parameter;


### PR DESCRIPTION
Closes #1115 and duplicates #959.

Currently, if we want to provide custom parser/serializer functions, we need to have the OID of the targeted data types from the database before even initializing the connection pool.

For native built-in types, the OIDs can be assumed stable, meaning always the same, so we could just check them manually and hard-code them.

For custom types added by database extensions, such as pgvector, the OID can't be assumed stable, which leaves us in a pickle.

Now we need to talk to the database before we can talk to the database.

Which is funny, because we already have a mechanism of fetching types from the database, but it only works for array types.

So in this PR I leverage the already existing mechanism but broadens it to fetch all data types from the database and populate two look-up tables: one that maps type names to OIDs and one that maps OIDs to type names. The current behavior of using type OIDs are preserved.

Finally, I have tweaked the behavior of type handling code to also accept strings along with numeric values and use the lookup tables to end up with the correct OIDs.

I have also updated the tests to cover this use case.

I'm also happy to make any changes required. In full disclosure, I have used LLMs to help me with this PR.