### PR TITLE
fix: select from values error

### DIFF
--- a/cf/src/types.js
+++ b/cf/src/types.js
@@ -129,7 +129,7 @@ function valuesBuilder(first, parameters, types, columns, options) {
 }
 
 function values(first, rest, parameters, types, options) {
-  const multi = Array.isArray(first[0])
+  const multi = Array.isArray(first)
   const columns = rest.length ? rest.flat() : Object.keys(multi ? first[0] : first)
   return valuesBuilder(multi ? first : [first], parameters, types, columns, options)
 }

--- a/cjs/src/types.js
+++ b/cjs/src/types.js
@@ -128,7 +128,7 @@ function valuesBuilder(first, parameters, types, columns, options) {
 }
 
 function values(first, rest, parameters, types, options) {
-  const multi = Array.isArray(first[0])
+  const multi = Array.isArray(first)
   const columns = rest.length ? rest.flat() : Object.keys(multi ? first[0] : first)
   return valuesBuilder(multi ? first : [first], parameters, types, columns, options)
 }

--- a/deno/src/types.js
+++ b/deno/src/types.js
@@ -129,7 +129,7 @@ function valuesBuilder(first, parameters, types, columns, options) {
 }
 
 function values(first, rest, parameters, types, options) {
-  const multi = Array.isArray(first[0])
+  const multi = Array.isArray(first)
   const columns = rest.length ? rest.flat() : Object.keys(multi ? first[0] : first)
   return valuesBuilder(multi ? first : [first], parameters, types, columns, options)
 }

--- a/src/types.js
+++ b/src/types.js
@@ -128,7 +128,7 @@ function valuesBuilder(first, parameters, types, columns, options) {
 }
 
 function values(first, rest, parameters, types, options) {
-  const multi = Array.isArray(first[0])
+  const multi = Array.isArray(first)
   const columns = rest.length ? rest.flat() : Object.keys(multi ? first[0] : first)
   return valuesBuilder(multi ? first : [first], parameters, types, columns, options)
 }


### PR DESCRIPTION
When taking value arrays, we should test if there are multiple rows passed to `sql`, not if the first row contains multiple elements. Otherwise we only catch 2D arrays but not arrays of objects.

Fixes #1073.

This fixes the issue in my project but I did not take the time to set up a local postgres instance in order to run the tests. Please review carefully, this code is pretty dense and I had less time for this fix than I wish I had.