### PR TITLE
Fix swallowed cursor error between batches in async iterator

### DIFF
--- a/cf/src/query.js
+++ b/cf/src/query.js
@@ -84,9 +84,15 @@ export class Query extends Promise {
       return (this.cursorFn = fn, this)
 
     let prev
+      , error = null
     return {
       [Symbol.asyncIterator]: () => ({
         next: () => {
+          if (error) {
+            const err = error
+            error = null
+            return Promise.reject(err)
+          }
           if (this.executed && !this.active)
             return { done: true }
 
@@ -97,7 +103,7 @@ export class Query extends Promise {
               return new Promise(r => prev = r)
             }
             this.resolve = () => (this.active = false, resolve({ done: true }))
-            this.reject = x => (this.active = false, reject(x))
+            this.reject = x => (this.active = false, error = x, reject(x))
           })
           this.execute()
           return promise

--- a/cjs/src/query.js
+++ b/cjs/src/query.js
@@ -84,9 +84,15 @@ const Query = module.exports.Query = class Query extends Promise {
       return (this.cursorFn = fn, this)
 
     let prev
+      , error = null
     return {
       [Symbol.asyncIterator]: () => ({
         next: () => {
+          if (error) {
+            const err = error
+            error = null
+            return Promise.reject(err)
+          }
           if (this.executed && !this.active)
             return { done: true }
 
@@ -97,7 +103,7 @@ const Query = module.exports.Query = class Query extends Promise {
               return new Promise(r => prev = r)
             }
             this.resolve = () => (this.active = false, resolve({ done: true }))
-            this.reject = x => (this.active = false, reject(x))
+            this.reject = x => (this.active = false, error = x, reject(x))
           })
           this.execute()
           return promise

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -1457,6 +1457,21 @@ t('Async Iterator Cursor custom with less results than batch size', async() => {
   return ['20', order.join(',')]
 })
 
+t('Async Iterator Cursor surfaces error arriving between batches', async() => {
+  const query = sql`select * from generate_series(1,5) as x`
+  const iterator = query.cursor(1)[Symbol.asyncIterator]()
+  await iterator.next()
+  query.reject(new Error('between-batch'))
+  let caught
+  try {
+    await iterator.next()
+  } catch (err) {
+    caught = err.message
+  }
+  await iterator.return()
+  return ['between-batch', caught]
+})
+
 t('Transform row', async() => {
   const sql = postgres({
     ...options,

--- a/deno/src/query.js
+++ b/deno/src/query.js
@@ -84,9 +84,15 @@ export class Query extends Promise {
       return (this.cursorFn = fn, this)
 
     let prev
+      , error = null
     return {
       [Symbol.asyncIterator]: () => ({
         next: () => {
+          if (error) {
+            const err = error
+            error = null
+            return Promise.reject(err)
+          }
           if (this.executed && !this.active)
             return { done: true }
 
@@ -97,7 +103,7 @@ export class Query extends Promise {
               return new Promise(r => prev = r)
             }
             this.resolve = () => (this.active = false, resolve({ done: true }))
-            this.reject = x => (this.active = false, reject(x))
+            this.reject = x => (this.active = false, error = x, reject(x))
           })
           this.execute()
           return promise

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -1459,6 +1459,21 @@ t('Async Iterator Cursor custom with less results than batch size', async() => {
   return ['20', order.join(',')]
 })
 
+t('Async Iterator Cursor surfaces error arriving between batches', async() => {
+  const query = sql`select * from generate_series(1,5) as x`
+  const iterator = query.cursor(1)[Symbol.asyncIterator]()
+  await iterator.next()
+  query.reject(new Error('between-batch'))
+  let caught
+  try {
+    await iterator.next()
+  } catch (err) {
+    caught = err.message
+  }
+  await iterator.return()
+  return ['between-batch', caught]
+})
+
 t('Transform row', async() => {
   const sql = postgres({
     ...options,

--- a/src/query.js
+++ b/src/query.js
@@ -84,9 +84,15 @@ export class Query extends Promise {
       return (this.cursorFn = fn, this)
 
     let prev
+      , error = null
     return {
       [Symbol.asyncIterator]: () => ({
         next: () => {
+          if (error) {
+            const err = error
+            error = null
+            return Promise.reject(err)
+          }
           if (this.executed && !this.active)
             return { done: true }
 
@@ -97,7 +103,7 @@ export class Query extends Promise {
               return new Promise(r => prev = r)
             }
             this.resolve = () => (this.active = false, resolve({ done: true }))
-            this.reject = x => (this.active = false, reject(x))
+            this.reject = x => (this.active = false, error = x, reject(x))
           })
           this.execute()
           return promise

--- a/tests/index.js
+++ b/tests/index.js
@@ -1457,6 +1457,21 @@ t('Async Iterator Cursor custom with less results than batch size', async() => {
   return ['20', order.join(',')]
 })
 
+t('Async Iterator Cursor surfaces error arriving between batches', async() => {
+  const query = sql`select * from generate_series(1,5) as x`
+  const iterator = query.cursor(1)[Symbol.asyncIterator]()
+  await iterator.next()
+  query.reject(new Error('between-batch'))
+  let caught
+  try {
+    await iterator.next()
+  } catch (err) {
+    caught = err.message
+  }
+  await iterator.return()
+  return ['between-batch', caught]
+})
+
 t('Transform row', async() => {
   const sql = postgres({
     ...options,


### PR DESCRIPTION
Fixes #1166.

When an error arrives on the connection between resolution of cursor batch
N and the consumer requesting batch N+1, the iterator's `next()` previously
overrode `this.reject` with a closure tied to the *current* batch's promise.
That promise was already settled by `cursorFn`, so the rejection was a no-op
— only `this.active = false` took effect. The next `next()` call then
short-circuited via `this.executed && !this.active` and returned
`{ done: true }`, silently completing the iteration with missing rows.

This stores the error alongside the `active = false` flag and re-throws it
on the next iteration, matching the behavior the caller would have seen had
the rejection landed during a pending batch.

Includes a regression test that simulates the race by triggering
`query.reject` after the first batch resolves and asserting the next
iterator step throws.