### PR TITLE
Guard nextWrite against null socket after async close

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -252,7 +252,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   function nextWrite(fn) {
-    const x = socket.write(chunk, fn)
+    const x = socket ? socket.write(chunk, fn) : false
     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
     chunk = nextWriteTimer = null
     return x


### PR DESCRIPTION
`nextWrite` can be scheduled via `setImmediate` and fire after `closed()` has nulled `socket`, crashing the whole process with:

> TypeError: Cannot read properties of null (reading 'write')

Fixes #1066, #1154