### PR TITLE
Transform JSON / JSONB parameter keys

### DIFF
--- a/cf/src/connection.js
+++ b/cf/src/connection.js
@@ -959,7 +959,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       type = types[i]
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x, options)
+        ? options.serializers[type](x, options, type)
         : '' + x
 
       prev = b.i

--- a/cf/src/connection.js
+++ b/cf/src/connection.js
@@ -959,7 +959,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       type = types[i]
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x)
+        ? options.serializers[type](x, options)
         : '' + x
 
       prev = b.i

--- a/cf/src/connection.js
+++ b/cf/src/connection.js
@@ -958,8 +958,9 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         return b.i32(0xFFFFFFFF)
 
       type = types[i]
+      x = options.transform.value.to ? options.transform.value.to(x, { type }) : x
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x, options, type)
+        ? options.serializers[type](x)
         : '' + x
 
       prev = b.i

--- a/cf/src/types.js
+++ b/cf/src/types.js
@@ -17,7 +17,7 @@ export const types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: x => JSON.stringify(x),
+    serialize: (x, options) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type: 3802 }) : x),
     parse: x => JSON.parse(x)
   },
   boolean: {
@@ -349,20 +349,26 @@ function createJsonTransform(fn) {
 toCamel.column = { from: toCamel }
 toCamel.value = { from: createJsonTransform(toCamel) }
 fromCamel.column = { to: fromCamel }
+fromCamel.value = { to: createJsonTransform(fromCamel) }
 
 export const camel = { ...toCamel }
 camel.column.to = fromCamel
+camel.value.to = fromCamel.value.to
 
 toPascal.column = { from: toPascal }
 toPascal.value = { from: createJsonTransform(toPascal) }
 fromPascal.column = { to: fromPascal }
+fromPascal.value = { to: createJsonTransform(fromPascal) }
 
 export const pascal = { ...toPascal }
 pascal.column.to = fromPascal
+pascal.value.to = fromPascal.value.to
 
 toKebab.column = { from: toKebab }
 toKebab.value = { from: createJsonTransform(toKebab) }
 fromKebab.column = { to: fromKebab }
+fromKebab.value = { to: createJsonTransform(fromKebab) }
 
 export const kebab = { ...toKebab }
 kebab.column.to = fromKebab
+kebab.value.to = fromKebab.value.to

--- a/cf/src/types.js
+++ b/cf/src/types.js
@@ -17,7 +17,7 @@ export const types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: (x, options, type) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type }) : x),
+    serialize: x => JSON.stringify(x),
     parse: x => JSON.parse(x)
   },
   boolean: {

--- a/cf/src/types.js
+++ b/cf/src/types.js
@@ -17,7 +17,7 @@ export const types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: (x, options) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type: 3802 }) : x),
+    serialize: (x, options, type) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type }) : x),
     parse: x => JSON.parse(x)
   },
   boolean: {
@@ -341,7 +341,9 @@ function createJsonTransform(fn) {
     return typeof x === 'object' && x !== null && (column.type === 114 || column.type === 3802)
       ? Array.isArray(x)
         ? x.map(x => jsonTransform(x, column))
-        : Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: jsonTransform(v, column) }), {})
+        : Object.getPrototypeOf(x) === Object.prototype || Object.getPrototypeOf(x) === null
+          ? Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: jsonTransform(v, column) }), {})
+          : x
       : x
   }
 }

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -957,7 +957,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       type = types[i]
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x)
+        ? options.serializers[type](x, options)
         : '' + x
 
       prev = b.i

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -957,7 +957,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       type = types[i]
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x, options)
+        ? options.serializers[type](x, options, type)
         : '' + x
 
       prev = b.i

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -956,8 +956,9 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         return b.i32(0xFFFFFFFF)
 
       type = types[i]
+      x = options.transform.value.to ? options.transform.value.to(x, { type }) : x
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x, options, type)
+        ? options.serializers[type](x)
         : '' + x
 
       prev = b.i

--- a/cjs/src/types.js
+++ b/cjs/src/types.js
@@ -16,7 +16,7 @@ const types = module.exports.types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: (x, options, type) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type }) : x),
+    serialize: x => JSON.stringify(x),
     parse: x => JSON.parse(x)
   },
   boolean: {

--- a/cjs/src/types.js
+++ b/cjs/src/types.js
@@ -16,7 +16,7 @@ const types = module.exports.types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: x => JSON.stringify(x),
+    serialize: (x, options) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type: 3802 }) : x),
     parse: x => JSON.parse(x)
   },
   boolean: {
@@ -348,20 +348,26 @@ function createJsonTransform(fn) {
 toCamel.column = { from: toCamel }
 toCamel.value = { from: createJsonTransform(toCamel) }
 fromCamel.column = { to: fromCamel }
+fromCamel.value = { to: createJsonTransform(fromCamel) }
 
 const camel = module.exports.camel = { ...toCamel }
 camel.column.to = fromCamel
+camel.value.to = fromCamel.value.to
 
 toPascal.column = { from: toPascal }
 toPascal.value = { from: createJsonTransform(toPascal) }
 fromPascal.column = { to: fromPascal }
+fromPascal.value = { to: createJsonTransform(fromPascal) }
 
 const pascal = module.exports.pascal = { ...toPascal }
 pascal.column.to = fromPascal
+pascal.value.to = fromPascal.value.to
 
 toKebab.column = { from: toKebab }
 toKebab.value = { from: createJsonTransform(toKebab) }
 fromKebab.column = { to: fromKebab }
+fromKebab.value = { to: createJsonTransform(fromKebab) }
 
 const kebab = module.exports.kebab = { ...toKebab }
 kebab.column.to = fromKebab
+kebab.value.to = fromKebab.value.to

--- a/cjs/src/types.js
+++ b/cjs/src/types.js
@@ -16,7 +16,7 @@ const types = module.exports.types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: (x, options) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type: 3802 }) : x),
+    serialize: (x, options, type) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type }) : x),
     parse: x => JSON.parse(x)
   },
   boolean: {
@@ -340,7 +340,9 @@ function createJsonTransform(fn) {
     return typeof x === 'object' && x !== null && (column.type === 114 || column.type === 3802)
       ? Array.isArray(x)
         ? x.map(x => jsonTransform(x, column))
-        : Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: jsonTransform(v, column) }), {})
+        : Object.getPrototypeOf(x) === Object.prototype || Object.getPrototypeOf(x) === null
+          ? Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: jsonTransform(v, column) }), {})
+          : x
       : x
   }
 }

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -106,6 +106,67 @@ t('Json', async() => {
   return ['hello,42', [x.a, x.b].join()]
 })
 
+t('Json transform parameter keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform nested parameter keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`
+    select ${ sql.json({ userNames: [{ firstName: 'Ada' }, { firstName: 'Grace' }] }) }#>>'{user_names,1,first_name}' as x
+  `)[0].x
+  return ['Grace', x]
+})
+
+t('Json transform result keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select '{"first_name":"Ada"}'::jsonb as x`)[0].x
+  return ['Ada', x.firstName]
+})
+
+t('Json without transform keeps parameter keys', async() => {
+  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'firstName' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform implicit json parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { firstName: 'Ada' } }::jsonb->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform implicit json type parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { firstName: 'Ada' } }::json->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform typed json parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ sql.typed({ firstName: 'Ada' }, 114) }->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
 t('implicit json', async() => {
   const x = (await sql`select ${ { a: 'hello', b: 42 } }::json as x`)[0].x
   return ['hello,42', [x.a, x.b].join()]

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -115,6 +115,11 @@ t('Json transform parameter keys', async() => {
   return ['1', x]
 })
 
+t('Json without transform keeps parameter keys', async() => {
+  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'aTest' as x`)[0].x
+  return ['1', x]
+})
+
 t('Json transform nested parameter keys', async() => {
   const sql = postgres({
     ...options,
@@ -133,11 +138,6 @@ t('Json transform result keys', async() => {
   })
   const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
   return [1, x.aTest]
-})
-
-t('Json without transform keeps parameter keys', async() => {
-  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'aTest' as x`)[0].x
-  return ['1', x]
 })
 
 t('Json transform implicit json parameters', async() => {

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -167,6 +167,16 @@ t('Json transform typed json parameters', async() => {
   return ['1', x]
 })
 
+t('Json transform toJSON parameter values', async() => {
+  const now = new Date()
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ sql.json({ aTest: now }) }->>'a_test' as x`)[0].x
+  return [now.toJSON(), x]
+})
+
 t('implicit json', async() => {
   const x = (await sql`select ${ { a: 'hello', b: 42 } }::json as x`)[0].x
   return ['hello,42', [x.a, x.b].join()]

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -111,8 +111,8 @@ t('Json transform parameter keys', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform nested parameter keys', async() => {
@@ -121,9 +121,9 @@ t('Json transform nested parameter keys', async() => {
     transform: postgres.camel
   })
   const x = (await sql`
-    select ${ sql.json({ userNames: [{ firstName: 'Ada' }, { firstName: 'Grace' }] }) }#>>'{user_names,1,first_name}' as x
+    select ${ sql.json({ aTest: [{ bTest: 1 }, { bTest: 2 }] }) }#>>'{a_test,1,b_test}' as x
   `)[0].x
-  return ['Grace', x]
+  return ['2', x]
 })
 
 t('Json transform result keys', async() => {
@@ -131,13 +131,13 @@ t('Json transform result keys', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select '{"first_name":"Ada"}'::jsonb as x`)[0].x
-  return ['Ada', x.firstName]
+  const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
+  return [1, x.aTest]
 })
 
 t('Json without transform keeps parameter keys', async() => {
-  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'firstName' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'aTest' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform implicit json parameters', async() => {
@@ -145,8 +145,8 @@ t('Json transform implicit json parameters', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ { firstName: 'Ada' } }::jsonb->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ { aTest: 1 } }::jsonb->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform implicit json type parameters', async() => {
@@ -154,8 +154,8 @@ t('Json transform implicit json type parameters', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ { firstName: 'Ada' } }::json->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ { aTest: 1 } }::json->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform typed json parameters', async() => {
@@ -163,8 +163,8 @@ t('Json transform typed json parameters', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ sql.typed({ firstName: 'Ada' }, 114) }->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ sql.typed({ aTest: 1 }, 114) }->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('implicit json', async() => {

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -131,33 +131,6 @@ t('Json transform nested parameter keys', async() => {
   return ['2', x]
 })
 
-t('Json transform result keys', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
-  return [1, x.aTest]
-})
-
-t('Json transform implicit json parameters', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  const x = (await sql`select ${ { aTest: 1 } }::jsonb->>'a_test' as x`)[0].x
-  return ['1', x]
-})
-
-t('Json transform implicit json type parameters', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  const x = (await sql`select ${ { aTest: 1 } }::json->>'a_test' as x`)[0].x
-  return ['1', x]
-})
-
 t('Json transform typed json parameters', async() => {
   const sql = postgres({
     ...options,
@@ -167,7 +140,34 @@ t('Json transform typed json parameters', async() => {
   return ['1', x]
 })
 
-t('Json transform toJSON parameter values', async() => {
+t('Json transform implicit jsonb parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { aTest: 1 } }::jsonb->>'a_test' as x`)[0].x
+  return ['1', x]
+})
+
+t('Json transform implicit json parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { aTest: 1 } }::json->>'a_test' as x`)[0].x
+  return ['1', x]
+})
+
+t('Json transform result keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
+  return [1, x.aTest]
+})
+
+t('Json transform does not transform parameter values with .toJSON()', async() => {
   const now = new Date()
   const sql = postgres({
     ...options,

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -960,7 +960,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       type = types[i]
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x, options)
+        ? options.serializers[type](x, options, type)
         : '' + x
 
       prev = b.i

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -959,8 +959,9 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         return b.i32(0xFFFFFFFF)
 
       type = types[i]
+      x = options.transform.value.to ? options.transform.value.to(x, { type }) : x
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x, options, type)
+        ? options.serializers[type](x)
         : '' + x
 
       prev = b.i

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -960,7 +960,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       type = types[i]
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x)
+        ? options.serializers[type](x, options)
         : '' + x
 
       prev = b.i

--- a/deno/src/types.js
+++ b/deno/src/types.js
@@ -17,7 +17,7 @@ export const types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: x => JSON.stringify(x),
+    serialize: (x, options) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type: 3802 }) : x),
     parse: x => JSON.parse(x)
   },
   boolean: {
@@ -349,20 +349,26 @@ function createJsonTransform(fn) {
 toCamel.column = { from: toCamel }
 toCamel.value = { from: createJsonTransform(toCamel) }
 fromCamel.column = { to: fromCamel }
+fromCamel.value = { to: createJsonTransform(fromCamel) }
 
 export const camel = { ...toCamel }
 camel.column.to = fromCamel
+camel.value.to = fromCamel.value.to
 
 toPascal.column = { from: toPascal }
 toPascal.value = { from: createJsonTransform(toPascal) }
 fromPascal.column = { to: fromPascal }
+fromPascal.value = { to: createJsonTransform(fromPascal) }
 
 export const pascal = { ...toPascal }
 pascal.column.to = fromPascal
+pascal.value.to = fromPascal.value.to
 
 toKebab.column = { from: toKebab }
 toKebab.value = { from: createJsonTransform(toKebab) }
 fromKebab.column = { to: fromKebab }
+fromKebab.value = { to: createJsonTransform(fromKebab) }
 
 export const kebab = { ...toKebab }
 kebab.column.to = fromKebab
+kebab.value.to = fromKebab.value.to

--- a/deno/src/types.js
+++ b/deno/src/types.js
@@ -17,7 +17,7 @@ export const types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: (x, options, type) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type }) : x),
+    serialize: x => JSON.stringify(x),
     parse: x => JSON.parse(x)
   },
   boolean: {

--- a/deno/src/types.js
+++ b/deno/src/types.js
@@ -17,7 +17,7 @@ export const types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: (x, options) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type: 3802 }) : x),
+    serialize: (x, options, type) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type }) : x),
     parse: x => JSON.parse(x)
   },
   boolean: {
@@ -341,7 +341,9 @@ function createJsonTransform(fn) {
     return typeof x === 'object' && x !== null && (column.type === 114 || column.type === 3802)
       ? Array.isArray(x)
         ? x.map(x => jsonTransform(x, column))
-        : Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: jsonTransform(v, column) }), {})
+        : Object.getPrototypeOf(x) === Object.prototype || Object.getPrototypeOf(x) === null
+          ? Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: jsonTransform(v, column) }), {})
+          : x
       : x
   }
 }

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -117,6 +117,11 @@ t('Json transform parameter keys', async() => {
   return ['1', x]
 })
 
+t('Json without transform keeps parameter keys', async() => {
+  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'aTest' as x`)[0].x
+  return ['1', x]
+})
+
 t('Json transform nested parameter keys', async() => {
   const sql = postgres({
     ...options,
@@ -135,11 +140,6 @@ t('Json transform result keys', async() => {
   })
   const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
   return [1, x.aTest]
-})
-
-t('Json without transform keeps parameter keys', async() => {
-  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'aTest' as x`)[0].x
-  return ['1', x]
 })
 
 t('Json transform implicit json parameters', async() => {

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -169,6 +169,16 @@ t('Json transform typed json parameters', async() => {
   return ['1', x]
 })
 
+t('Json transform toJSON parameter values', async() => {
+  const now = new Date()
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ sql.json({ aTest: now }) }->>'a_test' as x`)[0].x
+  return [now.toJSON(), x]
+})
+
 t('implicit json', async() => {
   const x = (await sql`select ${ { a: 'hello', b: 42 } }::json as x`)[0].x
   return ['hello,42', [x.a, x.b].join()]

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -113,8 +113,8 @@ t('Json transform parameter keys', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform nested parameter keys', async() => {
@@ -123,9 +123,9 @@ t('Json transform nested parameter keys', async() => {
     transform: postgres.camel
   })
   const x = (await sql`
-    select ${ sql.json({ userNames: [{ firstName: 'Ada' }, { firstName: 'Grace' }] }) }#>>'{user_names,1,first_name}' as x
+    select ${ sql.json({ aTest: [{ bTest: 1 }, { bTest: 2 }] }) }#>>'{a_test,1,b_test}' as x
   `)[0].x
-  return ['Grace', x]
+  return ['2', x]
 })
 
 t('Json transform result keys', async() => {
@@ -133,13 +133,13 @@ t('Json transform result keys', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select '{"first_name":"Ada"}'::jsonb as x`)[0].x
-  return ['Ada', x.firstName]
+  const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
+  return [1, x.aTest]
 })
 
 t('Json without transform keeps parameter keys', async() => {
-  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'firstName' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'aTest' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform implicit json parameters', async() => {
@@ -147,8 +147,8 @@ t('Json transform implicit json parameters', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ { firstName: 'Ada' } }::jsonb->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ { aTest: 1 } }::jsonb->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform implicit json type parameters', async() => {
@@ -156,8 +156,8 @@ t('Json transform implicit json type parameters', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ { firstName: 'Ada' } }::json->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ { aTest: 1 } }::json->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform typed json parameters', async() => {
@@ -165,8 +165,8 @@ t('Json transform typed json parameters', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ sql.typed({ firstName: 'Ada' }, 114) }->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ sql.typed({ aTest: 1 }, 114) }->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('implicit json', async() => {

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -133,33 +133,6 @@ t('Json transform nested parameter keys', async() => {
   return ['2', x]
 })
 
-t('Json transform result keys', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
-  return [1, x.aTest]
-})
-
-t('Json transform implicit json parameters', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  const x = (await sql`select ${ { aTest: 1 } }::jsonb->>'a_test' as x`)[0].x
-  return ['1', x]
-})
-
-t('Json transform implicit json type parameters', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  const x = (await sql`select ${ { aTest: 1 } }::json->>'a_test' as x`)[0].x
-  return ['1', x]
-})
-
 t('Json transform typed json parameters', async() => {
   const sql = postgres({
     ...options,
@@ -169,7 +142,34 @@ t('Json transform typed json parameters', async() => {
   return ['1', x]
 })
 
-t('Json transform toJSON parameter values', async() => {
+t('Json transform implicit jsonb parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { aTest: 1 } }::jsonb->>'a_test' as x`)[0].x
+  return ['1', x]
+})
+
+t('Json transform implicit json parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { aTest: 1 } }::json->>'a_test' as x`)[0].x
+  return ['1', x]
+})
+
+t('Json transform result keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
+  return [1, x.aTest]
+})
+
+t('Json transform does not transform parameter values with .toJSON()', async() => {
   const now = new Date()
   const sql = postgres({
     ...options,

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -108,6 +108,67 @@ t('Json', async() => {
   return ['hello,42', [x.a, x.b].join()]
 })
 
+t('Json transform parameter keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform nested parameter keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`
+    select ${ sql.json({ userNames: [{ firstName: 'Ada' }, { firstName: 'Grace' }] }) }#>>'{user_names,1,first_name}' as x
+  `)[0].x
+  return ['Grace', x]
+})
+
+t('Json transform result keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select '{"first_name":"Ada"}'::jsonb as x`)[0].x
+  return ['Ada', x.firstName]
+})
+
+t('Json without transform keeps parameter keys', async() => {
+  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'firstName' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform implicit json parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { firstName: 'Ada' } }::jsonb->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform implicit json type parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { firstName: 'Ada' } }::json->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform typed json parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ sql.typed({ firstName: 'Ada' }, 114) }->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
 t('implicit json', async() => {
   const x = (await sql`select ${ { a: 'hello', b: 42 } }::json as x`)[0].x
   return ['hello,42', [x.a, x.b].join()]

--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -333,7 +333,7 @@ declare namespace postgres {
   interface PostgresType<T = any> {
     to: number;
     from: number[];
-    serialize: (value: T, options?: ParsedOptions, type?: number) => unknown;
+    serialize: (value: T) => unknown;
     parse: (raw: any) => T;
   }
 
@@ -398,7 +398,7 @@ declare namespace postgres {
     pass: null;
     /** @inheritdoc */
     transform: Transform;
-    serializers: Record<number, (value: any, options?: ParsedOptions, type?: number) => unknown>;
+    serializers: Record<number, (value: any) => unknown>;
     parsers: Record<number, (value: any) => unknown>;
   }
 

--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -236,7 +236,7 @@ declare namespace postgres {
   function toPascal(str: string): string;
   namespace toPascal {
     namespace column { function from(str: string): string; }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value { function from(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert a PascalCase string to snake_case.
@@ -246,6 +246,7 @@ declare namespace postgres {
   function fromPascal(str: string): string;
   namespace fromPascal {
     namespace column { function to(str: string): string }
+    namespace value { function to(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert snake_case to and from PascalCase.
@@ -255,7 +256,10 @@ declare namespace postgres {
       function from(str: string): string;
       function to(str: string): string;
     }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value {
+      function from(str: unknown, column: Column<string>): unknown;
+      function to(str: unknown, column: Column<string>): unknown;
+    }
   }
   /**
    * Convert a snake_case string to camelCase.
@@ -265,7 +269,7 @@ declare namespace postgres {
   function toCamel(str: string): string;
   namespace toCamel {
     namespace column { function from(str: string): string; }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value { function from(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert a camelCase string to snake_case.
@@ -275,6 +279,7 @@ declare namespace postgres {
   function fromCamel(str: string): string;
   namespace fromCamel {
     namespace column { function to(str: string): string }
+    namespace value { function to(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert snake_case to and from camelCase.
@@ -284,7 +289,10 @@ declare namespace postgres {
       function from(str: string): string;
       function to(str: string): string;
     }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value {
+      function from(str: unknown, column: Column<string>): unknown;
+      function to(str: unknown, column: Column<string>): unknown;
+    }
   }
   /**
    * Convert a snake_case string to kebab-case.
@@ -294,7 +302,7 @@ declare namespace postgres {
   function toKebab(str: string): string;
   namespace toKebab {
     namespace column { function from(str: string): string; }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value { function from(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert a kebab-case string to snake_case.
@@ -304,6 +312,7 @@ declare namespace postgres {
   function fromKebab(str: string): string;
   namespace fromKebab {
     namespace column { function to(str: string): string }
+    namespace value { function to(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert snake_case to and from kebab-case.
@@ -313,7 +322,10 @@ declare namespace postgres {
       function from(str: string): string;
       function to(str: string): string;
     }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value {
+      function from(str: unknown, column: Column<string>): unknown;
+      function to(str: unknown, column: Column<string>): unknown;
+    }
   }
 
   const BigInt: PostgresType<bigint>;
@@ -321,7 +333,7 @@ declare namespace postgres {
   interface PostgresType<T = any> {
     to: number;
     from: number[];
-    serialize: (value: T) => unknown;
+    serialize: (value: T, options?: ParsedOptions) => unknown;
     parse: (raw: any) => T;
   }
 
@@ -386,7 +398,7 @@ declare namespace postgres {
     pass: null;
     /** @inheritdoc */
     transform: Transform;
-    serializers: Record<number, (value: any) => unknown>;
+    serializers: Record<number, (value: any, options?: ParsedOptions) => unknown>;
     parsers: Record<number, (value: any) => unknown>;
   }
 
@@ -404,7 +416,7 @@ declare namespace postgres {
       /** Transform function for values in result rows */
       from: ((value: any, column?: Column<string>) => any) | undefined;
       /** Transform function for interpolated values passed to tagged template literal */
-      to: undefined; // (value: any) => any
+      to: ((value: any, column?: Column<string>) => any) | undefined;
     };
     row: {
       /** Transform function for entire result rows */

--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -333,7 +333,7 @@ declare namespace postgres {
   interface PostgresType<T = any> {
     to: number;
     from: number[];
-    serialize: (value: T, options?: ParsedOptions) => unknown;
+    serialize: (value: T, options?: ParsedOptions, type?: number) => unknown;
     parse: (raw: any) => T;
   }
 
@@ -398,7 +398,7 @@ declare namespace postgres {
     pass: null;
     /** @inheritdoc */
     transform: Transform;
-    serializers: Record<number, (value: any, options?: ParsedOptions) => unknown>;
+    serializers: Record<number, (value: any, options?: ParsedOptions, type?: number) => unknown>;
     parsers: Record<number, (value: any) => unknown>;
   }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -957,7 +957,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       type = types[i]
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x)
+        ? options.serializers[type](x, options)
         : '' + x
 
       prev = b.i

--- a/src/connection.js
+++ b/src/connection.js
@@ -957,7 +957,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
       type = types[i]
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x, options)
+        ? options.serializers[type](x, options, type)
         : '' + x
 
       prev = b.i

--- a/src/connection.js
+++ b/src/connection.js
@@ -956,8 +956,9 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         return b.i32(0xFFFFFFFF)
 
       type = types[i]
+      x = options.transform.value.to ? options.transform.value.to(x, { type }) : x
       parameters[i] = x = type in options.serializers
-        ? options.serializers[type](x, options, type)
+        ? options.serializers[type](x)
         : '' + x
 
       prev = b.i

--- a/src/types.js
+++ b/src/types.js
@@ -16,7 +16,7 @@ export const types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: (x, options) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type: 3802 }) : x),
+    serialize: (x, options, type) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type }) : x),
     parse: x => JSON.parse(x)
   },
   boolean: {
@@ -340,7 +340,9 @@ function createJsonTransform(fn) {
     return typeof x === 'object' && x !== null && (column.type === 114 || column.type === 3802)
       ? Array.isArray(x)
         ? x.map(x => jsonTransform(x, column))
-        : Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: jsonTransform(v, column) }), {})
+        : Object.getPrototypeOf(x) === Object.prototype || Object.getPrototypeOf(x) === null
+          ? Object.entries(x).reduce((acc, [k, v]) => Object.assign(acc, { [fn(k)]: jsonTransform(v, column) }), {})
+          : x
       : x
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -16,7 +16,7 @@ export const types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: x => JSON.stringify(x),
+    serialize: (x, options) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type: 3802 }) : x),
     parse: x => JSON.parse(x)
   },
   boolean: {
@@ -348,20 +348,26 @@ function createJsonTransform(fn) {
 toCamel.column = { from: toCamel }
 toCamel.value = { from: createJsonTransform(toCamel) }
 fromCamel.column = { to: fromCamel }
+fromCamel.value = { to: createJsonTransform(fromCamel) }
 
 export const camel = { ...toCamel }
 camel.column.to = fromCamel
+camel.value.to = fromCamel.value.to
 
 toPascal.column = { from: toPascal }
 toPascal.value = { from: createJsonTransform(toPascal) }
 fromPascal.column = { to: fromPascal }
+fromPascal.value = { to: createJsonTransform(fromPascal) }
 
 export const pascal = { ...toPascal }
 pascal.column.to = fromPascal
+pascal.value.to = fromPascal.value.to
 
 toKebab.column = { from: toKebab }
 toKebab.value = { from: createJsonTransform(toKebab) }
 fromKebab.column = { to: fromKebab }
+fromKebab.value = { to: createJsonTransform(fromKebab) }
 
 export const kebab = { ...toKebab }
 kebab.column.to = fromKebab
+kebab.value.to = fromKebab.value.to

--- a/src/types.js
+++ b/src/types.js
@@ -16,7 +16,7 @@ export const types = {
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: (x, options, type) => JSON.stringify(options && options.transform.value.to ? options.transform.value.to(x, { type }) : x),
+    serialize: x => JSON.stringify(x),
     parse: x => JSON.parse(x)
   },
   boolean: {

--- a/tests/index.js
+++ b/tests/index.js
@@ -106,6 +106,67 @@ t('Json', async() => {
   return ['hello,42', [x.a, x.b].join()]
 })
 
+t('Json transform parameter keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform nested parameter keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`
+    select ${ sql.json({ userNames: [{ firstName: 'Ada' }, { firstName: 'Grace' }] }) }#>>'{user_names,1,first_name}' as x
+  `)[0].x
+  return ['Grace', x]
+})
+
+t('Json transform result keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select '{"first_name":"Ada"}'::jsonb as x`)[0].x
+  return ['Ada', x.firstName]
+})
+
+t('Json without transform keeps parameter keys', async() => {
+  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'firstName' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform implicit json parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { firstName: 'Ada' } }::jsonb->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform implicit json type parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { firstName: 'Ada' } }::json->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
+t('Json transform typed json parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ sql.typed({ firstName: 'Ada' }, 114) }->>'first_name' as x`)[0].x
+  return ['Ada', x]
+})
+
 t('implicit json', async() => {
   const x = (await sql`select ${ { a: 'hello', b: 42 } }::json as x`)[0].x
   return ['hello,42', [x.a, x.b].join()]

--- a/tests/index.js
+++ b/tests/index.js
@@ -115,6 +115,11 @@ t('Json transform parameter keys', async() => {
   return ['1', x]
 })
 
+t('Json without transform keeps parameter keys', async() => {
+  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'aTest' as x`)[0].x
+  return ['1', x]
+})
+
 t('Json transform nested parameter keys', async() => {
   const sql = postgres({
     ...options,
@@ -133,11 +138,6 @@ t('Json transform result keys', async() => {
   })
   const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
   return [1, x.aTest]
-})
-
-t('Json without transform keeps parameter keys', async() => {
-  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'aTest' as x`)[0].x
-  return ['1', x]
 })
 
 t('Json transform implicit json parameters', async() => {

--- a/tests/index.js
+++ b/tests/index.js
@@ -167,6 +167,16 @@ t('Json transform typed json parameters', async() => {
   return ['1', x]
 })
 
+t('Json transform toJSON parameter values', async() => {
+  const now = new Date()
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ sql.json({ aTest: now }) }->>'a_test' as x`)[0].x
+  return [now.toJSON(), x]
+})
+
 t('implicit json', async() => {
   const x = (await sql`select ${ { a: 'hello', b: 42 } }::json as x`)[0].x
   return ['hello,42', [x.a, x.b].join()]

--- a/tests/index.js
+++ b/tests/index.js
@@ -111,8 +111,8 @@ t('Json transform parameter keys', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform nested parameter keys', async() => {
@@ -121,9 +121,9 @@ t('Json transform nested parameter keys', async() => {
     transform: postgres.camel
   })
   const x = (await sql`
-    select ${ sql.json({ userNames: [{ firstName: 'Ada' }, { firstName: 'Grace' }] }) }#>>'{user_names,1,first_name}' as x
+    select ${ sql.json({ aTest: [{ bTest: 1 }, { bTest: 2 }] }) }#>>'{a_test,1,b_test}' as x
   `)[0].x
-  return ['Grace', x]
+  return ['2', x]
 })
 
 t('Json transform result keys', async() => {
@@ -131,13 +131,13 @@ t('Json transform result keys', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select '{"first_name":"Ada"}'::jsonb as x`)[0].x
-  return ['Ada', x.firstName]
+  const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
+  return [1, x.aTest]
 })
 
 t('Json without transform keeps parameter keys', async() => {
-  const x = (await sql`select ${ sql.json({ firstName: 'Ada' }) }->>'firstName' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ sql.json({ aTest: 1 }) }->>'aTest' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform implicit json parameters', async() => {
@@ -145,8 +145,8 @@ t('Json transform implicit json parameters', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ { firstName: 'Ada' } }::jsonb->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ { aTest: 1 } }::jsonb->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform implicit json type parameters', async() => {
@@ -154,8 +154,8 @@ t('Json transform implicit json type parameters', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ { firstName: 'Ada' } }::json->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ { aTest: 1 } }::json->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('Json transform typed json parameters', async() => {
@@ -163,8 +163,8 @@ t('Json transform typed json parameters', async() => {
     ...options,
     transform: postgres.camel
   })
-  const x = (await sql`select ${ sql.typed({ firstName: 'Ada' }, 114) }->>'first_name' as x`)[0].x
-  return ['Ada', x]
+  const x = (await sql`select ${ sql.typed({ aTest: 1 }, 114) }->>'a_test' as x`)[0].x
+  return ['1', x]
 })
 
 t('implicit json', async() => {

--- a/tests/index.js
+++ b/tests/index.js
@@ -131,33 +131,6 @@ t('Json transform nested parameter keys', async() => {
   return ['2', x]
 })
 
-t('Json transform result keys', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
-  return [1, x.aTest]
-})
-
-t('Json transform implicit json parameters', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  const x = (await sql`select ${ { aTest: 1 } }::jsonb->>'a_test' as x`)[0].x
-  return ['1', x]
-})
-
-t('Json transform implicit json type parameters', async() => {
-  const sql = postgres({
-    ...options,
-    transform: postgres.camel
-  })
-  const x = (await sql`select ${ { aTest: 1 } }::json->>'a_test' as x`)[0].x
-  return ['1', x]
-})
-
 t('Json transform typed json parameters', async() => {
   const sql = postgres({
     ...options,
@@ -167,7 +140,34 @@ t('Json transform typed json parameters', async() => {
   return ['1', x]
 })
 
-t('Json transform toJSON parameter values', async() => {
+t('Json transform implicit jsonb parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { aTest: 1 } }::jsonb->>'a_test' as x`)[0].x
+  return ['1', x]
+})
+
+t('Json transform implicit json parameters', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select ${ { aTest: 1 } }::json->>'a_test' as x`)[0].x
+  return ['1', x]
+})
+
+t('Json transform result keys', async() => {
+  const sql = postgres({
+    ...options,
+    transform: postgres.camel
+  })
+  const x = (await sql`select '{"a_test":1}'::jsonb as x`)[0].x
+  return [1, x.aTest]
+})
+
+t('Json transform does not transform parameter values with .toJSON()', async() => {
   const now = new Date()
   const sql = postgres({
     ...options,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -331,7 +331,7 @@ declare namespace postgres {
   interface PostgresType<T = any> {
     to: number;
     from: number[];
-    serialize: (value: T, options?: ParsedOptions) => unknown;
+    serialize: (value: T, options?: ParsedOptions, type?: number) => unknown;
     parse: (raw: any) => T;
   }
 
@@ -396,7 +396,7 @@ declare namespace postgres {
     pass: null;
     /** @inheritdoc */
     transform: Transform;
-    serializers: Record<number, (value: any, options?: ParsedOptions) => unknown>;
+    serializers: Record<number, (value: any, options?: ParsedOptions, type?: number) => unknown>;
     parsers: Record<number, (value: any) => unknown>;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -331,7 +331,7 @@ declare namespace postgres {
   interface PostgresType<T = any> {
     to: number;
     from: number[];
-    serialize: (value: T, options?: ParsedOptions, type?: number) => unknown;
+    serialize: (value: T) => unknown;
     parse: (raw: any) => T;
   }
 
@@ -396,7 +396,7 @@ declare namespace postgres {
     pass: null;
     /** @inheritdoc */
     transform: Transform;
-    serializers: Record<number, (value: any, options?: ParsedOptions, type?: number) => unknown>;
+    serializers: Record<number, (value: any) => unknown>;
     parsers: Record<number, (value: any) => unknown>;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -234,7 +234,7 @@ declare namespace postgres {
   function toPascal(str: string): string;
   namespace toPascal {
     namespace column { function from(str: string): string; }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value { function from(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert a PascalCase string to snake_case.
@@ -244,6 +244,7 @@ declare namespace postgres {
   function fromPascal(str: string): string;
   namespace fromPascal {
     namespace column { function to(str: string): string }
+    namespace value { function to(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert snake_case to and from PascalCase.
@@ -253,7 +254,10 @@ declare namespace postgres {
       function from(str: string): string;
       function to(str: string): string;
     }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value {
+      function from(str: unknown, column: Column<string>): unknown;
+      function to(str: unknown, column: Column<string>): unknown;
+    }
   }
   /**
    * Convert a snake_case string to camelCase.
@@ -263,7 +267,7 @@ declare namespace postgres {
   function toCamel(str: string): string;
   namespace toCamel {
     namespace column { function from(str: string): string; }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value { function from(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert a camelCase string to snake_case.
@@ -273,6 +277,7 @@ declare namespace postgres {
   function fromCamel(str: string): string;
   namespace fromCamel {
     namespace column { function to(str: string): string }
+    namespace value { function to(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert snake_case to and from camelCase.
@@ -282,7 +287,10 @@ declare namespace postgres {
       function from(str: string): string;
       function to(str: string): string;
     }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value {
+      function from(str: unknown, column: Column<string>): unknown;
+      function to(str: unknown, column: Column<string>): unknown;
+    }
   }
   /**
    * Convert a snake_case string to kebab-case.
@@ -292,7 +300,7 @@ declare namespace postgres {
   function toKebab(str: string): string;
   namespace toKebab {
     namespace column { function from(str: string): string; }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value { function from(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert a kebab-case string to snake_case.
@@ -302,6 +310,7 @@ declare namespace postgres {
   function fromKebab(str: string): string;
   namespace fromKebab {
     namespace column { function to(str: string): string }
+    namespace value { function to(str: unknown, column: Column<string>): unknown }
   }
   /**
    * Convert snake_case to and from kebab-case.
@@ -311,7 +320,10 @@ declare namespace postgres {
       function from(str: string): string;
       function to(str: string): string;
     }
-    namespace value { function from(str: unknown, column: Column<string>): string }
+    namespace value {
+      function from(str: unknown, column: Column<string>): unknown;
+      function to(str: unknown, column: Column<string>): unknown;
+    }
   }
 
   const BigInt: PostgresType<bigint>;
@@ -319,7 +331,7 @@ declare namespace postgres {
   interface PostgresType<T = any> {
     to: number;
     from: number[];
-    serialize: (value: T) => unknown;
+    serialize: (value: T, options?: ParsedOptions) => unknown;
     parse: (raw: any) => T;
   }
 
@@ -384,7 +396,7 @@ declare namespace postgres {
     pass: null;
     /** @inheritdoc */
     transform: Transform;
-    serializers: Record<number, (value: any) => unknown>;
+    serializers: Record<number, (value: any, options?: ParsedOptions) => unknown>;
     parsers: Record<number, (value: any) => unknown>;
   }
 
@@ -402,7 +414,7 @@ declare namespace postgres {
       /** Transform function for values in result rows */
       from: ((value: any, column?: Column<string>) => any) | undefined;
       /** Transform function for interpolated values passed to tagged template literal */
-      to: undefined; // (value: any) => any
+      to: ((value: any, column?: Column<string>) => any) | undefined;
     };
     row: {
       /** Transform function for entire result rows */


### PR DESCRIPTION
Hey @porsager, hope you're good! 👋

Postgres.js transforms JS property names passed through `sql(...)` helpers, eg. with `{ transform: postgres.camel }`:

```js
sql({ firstName: 'Ada' }) // { first_name: 'Ada' }
```

However, currently JSON parameter keys are not transformed 💥

```js
sql.json({ firstName: 'Ada' }) // {"firstName":"Ada"}
```

Maybe this was an oversight in my previous PR for "nested transforms":

- #460 

This PR adds JSON value transforms before serialization for the built-in case transforms, so JSON and JSONB parameters serialize transformed keys:

```js
sql.json({ firstName: 'Ada' }) // {"first_name":"Ada"}
```

This change also applies to JSON / JSONB data created via `sql.typed()` and type casts:

```js
sql.typed({ firstName: 'Ada' }, 114) // {"first_name":"Ada"}
sql`${ { firstName: 'Ada' } }::jsonb` // {"first_name":"Ada"}
```

- [x] Transform JSON / JSONB parameter keys
- [x] Add `value.to` transforms for camel, pascal, and kebab
- [x] Test nested objects, arrays, result parsing, and untransformed JSON
- [x] Test implicit and typed JSON parameters
- [x] Update types

AI disclosure: guided use of `gpt-5.5 high` through Codex CLI