### PR TITLE
Guard against null socket in nextWrite

### DIFF
--- a/cf/src/connection.js
+++ b/cf/src/connection.js
@@ -254,6 +254,8 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   function nextWrite(fn) {
+    if (!socket)
+      return false
     const x = socket.write(chunk, fn)
     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
     chunk = nextWriteTimer = null

--- a/cjs/src/connection.js
+++ b/cjs/src/connection.js
@@ -252,6 +252,8 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   function nextWrite(fn) {
+    if (!socket)
+      return false
     const x = socket.write(chunk, fn)
     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
     chunk = nextWriteTimer = null

--- a/deno/src/connection.js
+++ b/deno/src/connection.js
@@ -255,6 +255,8 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   function nextWrite(fn) {
+    if (!socket)
+      return false
     const x = socket.write(chunk, fn)
     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
     chunk = nextWriteTimer = null

--- a/src/connection.js
+++ b/src/connection.js
@@ -252,6 +252,8 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   function nextWrite(fn) {
+    if (!socket)
+      return false
     const x = socket.write(chunk, fn)
     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
     chunk = nextWriteTimer = null


### PR DESCRIPTION
## Problem

`nextWrite` can run after the connection has already closed, dereferencing a `null` socket and throwing an **uncatchable** exception that crashes the process:

```
TypeError: Cannot read properties of null (reading 'write')
    at Immediate.nextWrite (.../postgres/src/connection.js:255)
    at process.processImmediate (node:internal/timers)
```

### Sequence

1. A write smaller than 1024 bytes schedules `setImmediate(nextWrite)` instead of writing synchronously:
   https://github.com/porsager/postgres/blob/master/src/connection.js#L249-L252
2. The connection closes before that callback runs → `closed()` sets `socket = null` (after rejecting any in-flight query with `CONNECTION_CLOSED`).
3. The scheduled `setImmediate` fires → `nextWrite` calls `socket.write(...)` on `null` → fatal `TypeError`.

Because it is thrown from a `setImmediate` callback, it escapes the caller's `await`/`try-catch` and takes the whole process down. This shows up a lot behind connection poolers/proxies (PgBouncer, Supabase, Railway, fly.io) where transient closes are frequent, and especially with `prepare: false`.

## Fix

Early-return when the socket is already gone. By the time `socket === null`, `closed()` has already rejected the relevant query through the normal `CONNECTION_CLOSED` path, so the buffered write is moot — skipping it is safe and just avoids the crash. This mirrors the existing `socket && …` guard already used in `end()`.

```js
function nextWrite(fn) {
  if (!socket)
    return false
  const x = socket.write(chunk, fn)
  ...
}
```

`cjs`, `cf` and `deno` builds were regenerated via `npm run build`.

## Notes

- Reproduction is inherently timing-dependent (event-loop race on connection close), so I haven't added a deterministic test — happy to if you have a preferred way to simulate a mid-flight socket close.
- Per the bisect in #1154, the crash started surfacing around 3.4.4; `nextWrite` itself has never null-checked `socket`, so this guard is robust regardless of the timing change that exposed it.

Fixes #1066
Fixes #1154