### PR TITLE
Add sslnegotiation option type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,6 +1046,8 @@ const sql =
 
 For more information regarding `ssl` with `postgres`, check out the [Node.js documentation for tls](https://nodejs.org/dist/latest-v16.x/docs/api/tls.html#new-tlstlssocketsocket-options).
 
+Set `sslnegotiation: 'direct'` to skip the PostgreSQL SSLRequest negotiation and start TLS directly with ALPN.
+
 
 ### Multi-host connections - High Availability (HA)
 

--- a/deno/README.md
+++ b/deno/README.md
@@ -1042,6 +1042,8 @@ const sql =
 
 For more information regarding `ssl` with `postgres`, check out the [Node.js documentation for tls](https://nodejs.org/dist/latest-v16.x/docs/api/tls.html#new-tlstlssocketsocket-options).
 
+Set `sslnegotiation: 'direct'` to skip the PostgreSQL SSLRequest negotiation and start TLS directly with ALPN.
+
 
 ### Multi-host connections - High Availability (HA)
 

--- a/deno/types/index.d.ts
+++ b/deno/types/index.d.ts
@@ -48,6 +48,11 @@ interface BaseOptions<T extends Record<string, postgres.PostgresType>> {
   */
   ssl: 'require' | 'allow' | 'prefer' | 'verify-full' | boolean | object;
   /**
+   * SSL negotiation mode
+   * @default null
+   */
+  sslnegotiation: 'direct' | null;
+  /**
    * Max number of connections
    * @default 10
    */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,6 +46,11 @@ interface BaseOptions<T extends Record<string, postgres.PostgresType>> {
   */
   ssl: 'require' | 'allow' | 'prefer' | 'verify-full' | boolean | object;
   /**
+   * SSL negotiation mode
+   * @default null
+   */
+  sslnegotiation: 'direct' | null;
+  /**
    * Max number of connections
    * @default 10
    */


### PR DESCRIPTION
Fixes #1158

### Summary
- Add the missing `sslnegotiation` option to the TypeScript definitions.
- Keep the generated Deno type definition in sync.
- Document `sslnegotiation: 'direct'` in the SSL section.

### Verification
- `./node_modules/.bin/tsc --noEmit -p types/tsconfig.json` with a temporary type usage file covering `sslnegotiation: 'direct'`, `null`, and an invalid value.
- `node transpile.deno.js`
- `git diff --check`

### Disclosure
This contribution was prepared with AI assistance and reviewed before submission.