### PR TITLE
fix: settle COPY writable final callback on server error

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -389,6 +389,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
   function errored(err) {
     stream && (stream.destroy(err), stream = null)
+    final && (final(err), final = null)
     query && queryError(query, err)
     initial && (queryError(initial, err), initial = null)
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -2038,6 +2038,37 @@ t('Copy from abort', async() => {
   ]
 })
 
+t('Copy from settles instead of hanging when the server rejects the data', { timeout: 2 }, async() => {
+  await sql`create table test (x int, y int)`
+
+  let error
+  try {
+    await sql.begin(async sql => {
+      const writable = await sql`COPY test FROM STDIN`.writable()
+      await new Promise((resolve, reject) => {
+        writable.on('error', reject)
+        writable.on('finish', resolve)
+        // 3 columns in the row, 2 in the table -> server errors mid copy,
+        // after the writable's final() has already fired (.end() below)
+        writable.end('1\t2\t3\n')
+      })
+    })
+  } catch (err) {
+    error = err
+  }
+
+  const idleInTransaction = await sql`
+    select count(*)::int as count from pg_stat_activity
+    where state = 'idle in transaction (aborted)'
+  `
+
+  return [
+    true,
+    !!error && error.message.includes('extra data') && idleInTransaction[0].count === 0,
+    await sql`drop table test`
+  ]
+})
+
 t('multiple queries before connect', async() => {
   const sql = postgres({ ...options, max: 2 })
   const xs = await Promise.all([


### PR DESCRIPTION
Fixes #1173

## Problem

When `COPY ... FROM STDIN` fails after `.end()` has sent `CopyDone`, the
pending writable final callback is never called.

On the success path, `CommandComplete` calls the stored `final` callback.
On the failure path, Postgres sends `ErrorResponse` and `ReadyForQuery`
instead, which goes through `errored()`. That path cleaned up the current
stream/query state, but did not settle the pending `final` callback.

That leaves `stream.pipeline()` or any code awaiting the writable stuck
forever. Inside `sql.begin()`, the transaction callback never returns, so
`ROLLBACK` is not sent and the connection is left idle in an aborted
transaction.

## Fix

Call the pending `final` callback with the Postgres error from `errored()`:

```js
final && (final(err), final = null)
```

This makes the writable reject with the server error, allowing callers to
handle it normally and allowing `sql.begin()` to roll back.

The existing mid-write error path is unchanged: if the error arrives before
`.end()` stores `final`, `stream.destroy(err)` still handles it.

## Testing

- Added a regression test for a failed `COPY FROM STDIN` after `.end()`
- Verified the writable rejects with the real Postgres error
- Verified no connection is left `idle in transaction (aborted)`