### PR TITLE
Parse and serialize timestamp infinity as Infinity - fixes #728

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -28,8 +28,8 @@ export const types = {
   date: {
     to: 1184,
     from: [1082, 1114, 1184],
-    serialize: x => (x instanceof Date ? x : new Date(x)).toISOString(),
-    parse: x => new Date(x)
+    serialize: x => x === Infinity ? 'infinity' : x === -Infinity ? '-infinity' : (x instanceof Date ? x : new Date(x)).toISOString(),
+    parse: x => x === 'infinity' ? Infinity : x === '-infinity' ? -Infinity : new Date(x)
   },
   bytea: {
     to: 17,

--- a/tests/index.js
+++ b/tests/index.js
@@ -101,6 +101,22 @@ t('Date', async() => {
   return [0, now - (await sql`select ${ now } as x`)[0].x]
 })
 
+t('Infinity timestamp parses to Infinity', async() =>
+  [Infinity, (await sql`select 'infinity'::timestamptz as x`)[0].x]
+)
+
+t('-Infinity timestamp parses to -Infinity', async() =>
+  [-Infinity, (await sql`select '-infinity'::timestamptz as x`)[0].x]
+)
+
+t('Infinity timestamp round-trips', async() =>
+  [Infinity, (await sql`select ${ sql.typed(Infinity, 1184) } as x`)[0].x]
+)
+
+t('-Infinity timestamp round-trips', async() =>
+  [-Infinity, (await sql`select ${ sql.typed(-Infinity, 1184) } as x`)[0].x]
+)
+
 t('Json', async() => {
   const x = (await sql`select ${ sql.json({ a: 'hello', b: 42 }) } as x`)[0].x
   return ['hello,42', [x.a, x.b].join()]


### PR DESCRIPTION
`timestamptz`/`timestamp`/`date` columns can hold the special values `infinity` and `-infinity` — e.g. `expires timestamptz DEFAULT 'infinity'` for "never expires". Postgres.js currently parses these through `new Date('infinity')`, which yields an `Invalid Date`: `.getTime()` is `NaN`, so every subsequent date comparison silently breaks. Reported in #728 (with a second report confirming it).

node-postgres maps these to JS `Infinity` / `-Infinity` (via `postgres-date`). This brings postgres.js in line.

### Change (`src/types.js`, `date` type)

- **parse:** `'infinity' → Infinity`, `'-infinity' → -Infinity`, otherwise `new Date(x)` as before.
- **serialize:** `Infinity → 'infinity'`, `-Infinity → '-infinity'`, otherwise unchanged. Without this half, writing a parsed `Infinity` back through the date serializer hits `new Date(Infinity).toISOString()`, which throws `RangeError: Invalid time value` — the two halves together let the value round-trip.

### Behavior change (intentional)

Reading an `infinity` timestamp now returns the number `Infinity` instead of an `Invalid Date`. Code doing `row.col.getTime()` was already getting `NaN`; it now gets a value that compares correctly (`Infinity > anyDate`). This matches node-postgres and the underlying Postgres semantics.

### Tests

Added alongside the existing `Date` cases — parse of `'infinity'`/`'-infinity'`, plus round-trip via `sql.typed(±Infinity, 1184)`. Verified failing on `main` (parse → `Invalid Date`, round-trip → `RangeError`) and passing after the change; the normal `Date` path is unaffected.

Refs: [Postgres date/time special values](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-SPECIAL-VALUES), node-postgres / `postgres-date`.