### PR TITLE
Fix timestamps with years before 100 being parsed as 19xx/20xx

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -29,7 +29,10 @@ export const types = {
     to: 1184,
     from: [1082, 1114, 1184],
     serialize: x => (x instanceof Date ? x : new Date(x)).toISOString(),
-    parse: x => new Date(x)
+    parse: x => {
+      const iso = x.replace(' ', 'T')
+      return new Date(iso === x ? x : iso.replace(/([+-]\d{2})$/, '$1:00'))
+    }
   },
   bytea: {
     to: 17,

--- a/tests/index.js
+++ b/tests/index.js
@@ -101,6 +101,10 @@ t('Date', async() => {
   return [0, now - (await sql`select ${ now } as x`)[0].x]
 })
 
+t('Date before year 100', async() =>
+  ['0050-06-15T12:30:00.000Z', (await sql`select '0050-06-15 12:30:00+00'::timestamptz as x`)[0].x.toISOString()]
+)
+
 t('Json', async() => {
   const x = (await sql`select ${ sql.json({ a: 'hello', b: 42 }) } as x`)[0].x
   return ['hello,42', [x.a, x.b].join()]


### PR DESCRIPTION
## Problem

The `date` / `timestamp` / `timestamptz` parser is `parse: x => new Date(x)`, which hands PostgreSQL's text output straight to JavaScript's `Date`. For a year below 100, PostgreSQL's text (e.g. `0050-06-15 12:30:00+00`) is not strict ISO 8601 (space separator, two-digit offset), so `new Date` falls back to its legacy parser, which maps the year into the 1900s or returns garbage:

```js
const sql = postgres()
;(await sql`select '0050-06-15 12:30:00+00'::timestamptz as x`)[0].x  // 1950-06-15  (should be 0050)
;(await sql`select '0099-06-15 12:30:00+00'::timestamptz as x`)[0].x  // 1999-06-15  (should be 0099)
;(await sql`select '0001-06-15 12:30:00+00'::timestamptz as x`)[0].x  // 2015-01-06  (garbage)
;(await sql`select '0023-06-15 12:30:00+00'::timestamptz as x`)[0].x  // Invalid Date
```

Any timestamp with a year of 1 to 99 is silently corrupted (off by ~1900 years, or `Invalid Date`).

## Fix

Normalize the text to ISO 8601 before `new Date`: replace the date/time space with `T`, and expand a two-digit timezone offset `+HH` to `+HH:00`. The ISO parser then handles years below 100 correctly. Years 100 and above, and plain `date` values, produce byte-identical output to before.

Verified against PostgreSQL 17 that the parsed values now match the `pg` driver for years 1 through 2020 across `date`, `timestamp`, and `timestamptz`, and that years >= 100 are unchanged.

## Test

Added `Date before year 100` to `tests/index.js`. It fails before the change and passes after.
