### PR TITLE
fix: resolve domain types to their base type serializer/parser

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -768,15 +768,16 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   async function fetchArrayTypes() {
       needsTypes = false
       const [types, domains] = await new Query([`
-        select b.oid, b.typarray
-        from pg_catalog.pg_type a
-        left join pg_catalog.pg_type b on b.oid = a.typelem
-        where a.typcategory = 'A'
-        group by b.oid, b.typarray
-        order by b.oid;
-        select oid, typbasetype
-        from pg_catalog.pg_type
-        where typtype = 'd'
+          select b.oid, b.typarray
+          from pg_catalog.pg_type a
+          left join pg_catalog.pg_type b on b.oid = a.typelem
+          where a.typcategory = 'A'
+          group by b.oid, b.typarray
+          order by b.oid;
+          select oid, typbasetype
+          from pg_catalog.pg_type
+          where typtype = 'd'
+          order by oid
       `], [], execute, null, { simple: true })
       types.forEach(({ oid, typarray }) => addArrayType(oid, typarray))
       domains.forEach(({ oid, typbasetype }) => addDomainType(oid, typbasetype))

--- a/src/connection.js
+++ b/src/connection.js
@@ -766,17 +766,21 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
   }
 
   async function fetchArrayTypes() {
-    needsTypes = false
-    const types = await new Query([`
-      select b.oid, b.typarray
-      from pg_catalog.pg_type a
-      left join pg_catalog.pg_type b on b.oid = a.typelem
-      where a.typcategory = 'A'
-      group by b.oid, b.typarray
-      order by b.oid
-    `], [], execute)
-    types.forEach(({ oid, typarray }) => addArrayType(oid, typarray))
-  }
+      needsTypes = false
+      const [types, domains] = await new Query([`
+        select b.oid, b.typarray
+        from pg_catalog.pg_type a
+        left join pg_catalog.pg_type b on b.oid = a.typelem
+        where a.typcategory = 'A'
+        group by b.oid, b.typarray
+        order by b.oid;
+        select oid, typbasetype
+        from pg_catalog.pg_type
+        where typtype = 'd'
+      `], [], execute, null, { simple: true })
+      types.forEach(({ oid, typarray }) => addArrayType(oid, typarray))
+      domains.forEach(({ oid, typbasetype }) => addDomainType(oid, typbasetype))
+    }
 
   function addArrayType(oid, typarray) {
     if (!!options.parsers[typarray] && !!options.serializers[typarray]) return
@@ -785,6 +789,11 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     options.parsers[typarray] = (xs) => arrayParser(xs, parser, typarray)
     options.parsers[typarray].array = true
     options.serializers[typarray] = (xs) => arraySerializer(xs, options.serializers[oid], options, typarray)
+  }
+
+  function addDomainType(oid, basetype) {
+    if (options.parsers[basetype]) options.parsers[oid] = options.parsers[basetype]
+    if (options.serializers[basetype]) options.serializers[oid] = options.serializers[basetype]
   }
 
   function tryNext(x, xs) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -166,6 +166,21 @@ t('Domain type wrapping an array resolves to the base type serializer', async() 
   ]
 })
 
+t('Nested domain types resolve through to their base type serializer', async() => {
+  await sql`drop domain if exists pg_test_domain_nested_child cascade`
+  await sql`drop domain if exists pg_test_domain_nested_parent cascade`
+  await sql`create domain pg_test_domain_nested_parent as text[]`
+  await sql`create domain pg_test_domain_nested_child as pg_test_domain_nested_parent`
+  await sql`create table test (x pg_test_domain_nested_child)`
+  return [
+    'a,b',
+    (await sql`insert into test values (${ sql.array(['a', 'b']) }) returning x`)[0].x.join(','),
+    await sql`drop table test`,
+    await sql`drop domain pg_test_domain_nested_child`,
+    await sql`drop domain pg_test_domain_nested_parent`
+  ]
+})
+
 t('Escapes', async() => {
   return ['hej"hej', Object.keys((await sql`select 1 as ${ sql('hej"hej') }`)[0])[0]]
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -154,6 +154,18 @@ t('Escape in arrays', async() =>
   ['Hello "you",c:\\windows', (await sql`select ${ sql.array(['Hello "you"', 'c:\\windows']) } as x`)[0].x.join(',')]
 )
 
+t('Domain type wrapping an array resolves to the base type serializer', async() => {
+  await sql`drop domain if exists pg_test_domain_array cascade`
+  await sql`create domain pg_test_domain_array as text[]`
+  await sql`create table test (x pg_test_domain_array)`
+  return [
+    'a,b',
+    (await sql`insert into test values (${ sql.array(['a', 'b']) }) returning x`)[0].x.join(','),
+    await sql`drop table test`,
+    await sql`drop domain pg_test_domain_array`
+  ]
+})
+
 t('Escapes', async() => {
   return ['hej"hej', Object.keys((await sql`select 1 as ${ sql('hej"hej') }`)[0])[0]]
 })


### PR DESCRIPTION
Fixes #592

Postgres domain types (CREATE DOMAIN x AS text[]) aren't tagged with typcategory = 'A', so fetchArrayTypes() never registered a serializer/parser for them — inserting into a domain-typed array column failed with malformed array literal.

This adds a lookup for domain types (typtype = 'd'), resolving each domain's OID back to its base type (typbasetype) and reusing whichever serializer/parser is already registered for that base type.

Both lookups are combined into a single round-trip (multi-statement query, same pattern already used in fetchState()) rather than two separate queries. An earlier version of this fix used two sequential awaited queries, which introduced a race condition: needsTypes flips to false after the first round-trip completes, which lets the connection execute the next queued query before a second query would have finished populating the serializer map. Bundling both into one round-trip avoids that.

Verified locally against PostgreSQL 18 with both a domain-wrapped array column and a plain array column, confirming correct storage and no regression in the plain-array path. Added a test following the existing array-test conventions in tests/index.js; wasn't able to run the full local suite due to its Linux-oriented bootstrap script (creates test users via bare psql/createdb calls), but the new test's logic is verified in isolation and CI should cover the rest.