### PR TITLE
Fix unbounded reconnect loop when all hosts fail during connect

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -447,9 +447,14 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     socket.removeAllListeners()
     socket = null
 
-    if (initial)
-      return reconnect()
+    if (initial) {
+      if (options.host[++retries])
+        return reconnect()
 
+      errored(Errors.connection('CONNECTION_CLOSED', options, socket))
+    }
+
+    retries = 0
     !hadError && (query || sent.length) && error(Errors.connection('CONNECTION_CLOSED', options, socket))
     closedTime = performance.now()
     hadError && options.shared.retries++

--- a/tests/index.js
+++ b/tests/index.js
@@ -1060,6 +1060,25 @@ t('Connection errors are caught using begin()', {
   ]
 })
 
+t('Connection errors are caught when all hosts fail', {
+  timeout: 2
+}, async() => {
+  let error
+  try {
+    const sql = postgres({ host: ['localhost', 'localhost'], port: [1, 1] })
+
+    await sql`select 1`
+  } catch (err) {
+    error = err
+  }
+
+  return [
+    true,
+    error.code === 'ECONNREFUSED' ||
+    error.message === 'Connection refused (os error 61)'
+  ]
+})
+
 t('dynamic table name', async() => {
   await sql`create table test(a int)`
   return [


### PR DESCRIPTION
`Connection`'s local `retries` counter is read in two places — `error()`'s `options.host[retries + 1]` guard and `tryNext()`'s `options.host[retries]` — and reset in the ready handler, but nothing ever increments it (`closed()` bumps `options.shared.retries` instead, and for connecting sockets it returns early before reaching that line anyway).

So with multiple hosts configured, a connect-phase failure always finds a "next host": `error()` swallows it, `closed()` reconnects, forever. The pending query never settles:

```js
const sql = postgres({ host: 'localhost', port: 1 })
await sql`select 1` // rejects with ECONNREFUSED in ~10ms

const sql = postgres({ host: ['localhost', 'localhost'], port: [1, 1] })
await sql`select 1` // never settles
```

This change counts each failed attempt in `closed()` and stops reconnecting once the host list is exhausted. A socket error on the last host already rejects the pending query in `error()` with the original error (e.g. `ECONNREFUSED`), and a clean close with no hosts left now rejects with `CONNECTION_CLOSED`. The counter resets when the cycle ends, so the next query sweeps the full host list again; a successful connect resets it as before.

The added test mirrors the existing single-host `ECONNREFUSED` test — it times out on master and passes with the fix.