### PR TITLE
Feature: reusing matching and duplicated positional parameters in prepared statements

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -76,21 +76,25 @@ export function handleValue(x, parameters, types, options) {
   let value = x instanceof Parameter ? x.value : x
   if (value === undefined) {
     x instanceof Parameter
-      ? x.value = options.transform.undefined
+      ? value = x.value = options.transform.undefined
       : value = x = options.transform.undefined
 
     if (value === undefined)
       throw Errors.generic('UNDEFINED_VALUE', 'Undefined values are not allowed')
   }
 
-  return '$' + (types.push(
+  const type =
     x instanceof Parameter
-      ? (parameters.push(x.value), x.array
-        ? x.array[x.type || inferType(x.value)] || x.type || firstIsString(x.value)
+      ? x.array
+        ? x.array[x.type || inferType(value)] || x.type || firstIsString(value)
         : x.type
-      )
-      : (parameters.push(x), inferType(x))
-  ))
+      : inferType(value)
+
+  for (let i = 0; i < parameters.length; i++)
+    if (parameters[i] === value && types[i] === type) return '$' + (i + 1)
+
+  parameters.push(value)
+  return '$' + types.push(type)
 }
 
 const defaultHandlers = typeHandlers(types)


### PR DESCRIPTION
Assuming there usually are only handful of unique positional parameters used per prepared statement, we can rather efficiently find matching ones. This practically moves some of the processing away from Postgres server, to be simplified already on javascript-client side.

Escaping and encoding parameters still happens fully on the Postgres server side. 

## Input
```javascript
await sql`
  WITH organization AS (
    SELECT organization_name
    FROM our_schema.organizations
    WHERE organization_id = ${organization_id}
    LIMIT 1
  )

  SELECT
    asset_name,
    organization_name
  FROM our_schema.assets
  CROSS JOIN organization
  WHERE
    organization_id = ${organization_id}
    AND asset_id = ${asset_id}
  LIMIT 1`
```

## Output
```sql
WITH organization AS (
  SELECT organization_name
  FROM our_schema.organizations
  WHERE organization_id = $1
  LIMIT 1
)

SELECT
  asset_name,
  organization_name
FROM our_schema.assets
CROSS JOIN organization
WHERE
  organization_id = $1
  AND asset_id = $2
LIMIT 1
```

I'm not fully convinced myself of this actually being something we would want, but leaving it here in case this would be deemed useful by others.