### PR TITLE
Fix: Do not mutate parameters when serializing in Bind - fixes multiple serialization on retry

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -956,7 +956,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         return b.i32(0xFFFFFFFF)
 
       type = types[i]
-      parameters[i] = x = type in options.serializers
+      x = type in options.serializers
         ? options.serializers[type](x)
         : '' + x
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -1824,6 +1824,87 @@ t('Recreate prepared statements on RevalidateCachedQuery error', async() => {
   ]
 })
 
+t('Does not re-serialize json parameters when retrying on RevalidateCachedQuery error', async() => {
+  const update = () => sql`update test set config = ${ sql.json({ warmup: 2100000000, ticksLimit: 5000 }) } returning *`
+  await sql`create table test (id int, config jsonb)`
+  await sql`insert into test values (1, '{}')`
+  await update()
+  await sql`alter table test add column extra int`
+  await update()
+  return [
+    'object',
+    (await sql`select jsonb_typeof(config) as type from test`)[0].type,
+    await sql`drop table test`
+  ]
+})
+
+t('Does not re-serialize json parameters when retrying on FetchPreparedStatement error', async() => {
+  const insert = () => sql`insert into test (config) values (${ sql.json({ warmup: 2100000000 }) })`
+  await sql`create table test (config jsonb)`
+  await insert()
+  await sql`deallocate all`
+  await insert()
+  return [
+    'object,object',
+    (await sql`select jsonb_typeof(config) as type from test`).map(x => x.type).join(),
+    await sql`drop table test`
+  ]
+})
+
+t('Does not re-serialize boolean parameters when retrying on RevalidateCachedQuery error', async() => {
+  const update = () => sql`update test set enabled = ${ true } returning *`
+  await sql`create table test (id int, enabled bool)`
+  await sql`insert into test values (1, false)`
+  await update()
+  await sql`alter table test add column extra int`
+  await update()
+  return [
+    true,
+    (await sql`select enabled from test`)[0].enabled,
+    await sql`drop table test`
+  ]
+})
+
+t('Does not re-serialize boolean parameters when retrying on FetchPreparedStatement error', async() => {
+  const insert = () => sql`insert into test (enabled) values (${ true })`
+  await sql`create table test (enabled bool)`
+  await insert()
+  await sql`deallocate all`
+  await insert()
+  return [
+    'true,true',
+    (await sql`select enabled from test`).map(x => x.enabled).join(),
+    await sql`drop table test`
+  ]
+})
+
+t('Does not re-serialize bytea parameters when retrying on RevalidateCachedQuery error', async() => {
+  const update = () => sql`update test set data = ${ Buffer.from('hello') } returning *`
+  await sql`create table test (id int, data bytea)`
+  await sql`insert into test values (1, null)`
+  await update()
+  await sql`alter table test add column extra int`
+  await update()
+  return [
+    'hello',
+    (await sql`select data from test`)[0].data.toString(),
+    await sql`drop table test`
+  ]
+})
+
+t('Does not re-serialize bytea parameters when retrying on FetchPreparedStatement error', async() => {
+  const insert = () => sql`insert into test (data) values (${ Buffer.from('hello') })`
+  await sql`create table test (data bytea)`
+  await insert()
+  await sql`deallocate all`
+  await insert()
+  return [
+    'hello,hello',
+    (await sql`select data from test`).map(x => x.data.toString()).join(),
+    await sql`drop table test`
+  ]
+})
+
 t('Properly throws routine error on not prepared statements', async() => {
   await sql`create table x (x text[])`
   const { routine } = await sql.unsafe(`


### PR DESCRIPTION
Fixes #1197

`Bind` stored each serialized value back into `query.parameters`, so when a prepared query was retried after a `FetchPreparedStatement` or `RevalidateCachedQuery` error, the already serialized values went through the serializers a second time: `json`/`jsonb` objects got stored as JSON strings, `boolean true` silently flipped to `false`, and `bytea` buffers were hex-encoded twice. See #1197 for the full mechanism and a standalone reproduction.

Serialize into a local variable instead and leave `query.parameters` untouched - the retry itself is unchanged and still transparent, it just binds the original values now.

- The first commit adds six tests covering both retry routines and all three affected built-in serializers; each fails without the fix.
- The second commit is the one-line fix.
- The full test suite passes (ESM run against PostgreSQL 16).
