### PR TITLE
Clear leftover begin() onclose handler after the transaction settles

### DIFF
--- a/cf/src/index.js
+++ b/cf/src/index.js
@@ -247,6 +247,8 @@ function Postgres(a, b) {
       ])
     } catch (error) {
       throw error
+    } finally {
+      connection && (connection.onclose = null)
     }
 
     async function scope(c, fn, name) {

--- a/cjs/src/index.js
+++ b/cjs/src/index.js
@@ -246,6 +246,8 @@ function Postgres(a, b) {
       ])
     } catch (error) {
       throw error
+    } finally {
+      connection && (connection.onclose = null)
     }
 
     async function scope(c, fn, name) {

--- a/cjs/tests/index.js
+++ b/cjs/tests/index.js
@@ -2420,6 +2420,21 @@ t('Ensure transactions throw if connection is closed dwhile there is no query', 
   return ['CONNECTION_CLOSED', x.code]
 })
 
+t('Does not reject leftover begin onclose after commit', async() => {
+  const sql = postgres({ ...options, max: 1 })
+  const rejections = []
+  const onUnhandled = reason => rejections.push(reason)
+  process.on('unhandledRejection', onUnhandled)
+  try {
+    await sql.begin(sql => sql`select 1`)
+    await sql.end({ timeout: 0 })
+    await delay(50)
+  } finally {
+    process.off('unhandledRejection', onUnhandled)
+  }
+  return [0, rejections.length]
+})
+
 t('Custom socket', {}, async() => {
   let result
   const sql = postgres({

--- a/deno/src/index.js
+++ b/deno/src/index.js
@@ -247,6 +247,8 @@ function Postgres(a, b) {
       ])
     } catch (error) {
       throw error
+    } finally {
+      connection && (connection.onclose = null)
     }
 
     async function scope(c, fn, name) {

--- a/deno/tests/index.js
+++ b/deno/tests/index.js
@@ -2422,6 +2422,21 @@ t('Ensure transactions throw if connection is closed dwhile there is no query', 
   return ['CONNECTION_CLOSED', x.code]
 })
 
+t('Does not reject leftover begin onclose after commit', async() => {
+  const sql = postgres({ ...options, max: 1 })
+  const rejections = []
+  const onUnhandled = reason => rejections.push(reason)
+  process.on('unhandledRejection', onUnhandled)
+  try {
+    await sql.begin(sql => sql`select 1`)
+    await sql.end({ timeout: 0 })
+    await delay(50)
+  } finally {
+    process.off('unhandledRejection', onUnhandled)
+  }
+  return [0, rejections.length]
+})
+
 t('Custom socket', {}, async() => {
   let result
   const sql = postgres({

--- a/src/index.js
+++ b/src/index.js
@@ -246,6 +246,8 @@ function Postgres(a, b) {
       ])
     } catch (error) {
       throw error
+    } finally {
+      connection && (connection.onclose = null)
     }
 
     async function scope(c, fn, name) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -2420,6 +2420,21 @@ t('Ensure transactions throw if connection is closed dwhile there is no query', 
   return ['CONNECTION_CLOSED', x.code]
 })
 
+t('Does not reject leftover begin onclose after commit', async() => {
+  const sql = postgres({ ...options, max: 1 })
+  const rejections = []
+  const onUnhandled = reason => rejections.push(reason)
+  process.on('unhandledRejection', onUnhandled)
+  try {
+    await sql.begin(sql => sql`select 1`)
+    await sql.end({ timeout: 0 })
+    await delay(50)
+  } finally {
+    process.off('unhandledRejection', onUnhandled)
+  }
+  return [0, rejections.length]
+})
+
 t('Custom socket', {}, async() => {
   let result
   const sql = postgres({


### PR DESCRIPTION
## Summary
- `sql.begin()` races the transaction against `connection.onclose = reject` so a disconnect during the transaction can fail the `begin()` promise.
- After a successful commit that handler is never cleared, so a later pool disconnect (idle timeout, `sql.end()`, server-side recycle) still calls `reject`. The raced promise is already settled, so this becomes `unhandledRejection` — often `undefined`.
- Clear `connection.onclose` in `finally`. Add a regression test that commits a transaction, then closes the pool and asserts no leftover rejection.

## Test plan
- [ ] `node tests/index.js` (needs the usual `postgres_js_test` setup)
- [ ] Confirm the new test fails on current master and passes with this change
- [ ] After `await sql.begin(...)`, close the connection via `sql.end({ timeout: 0 })` or idle timeout and confirm no `unhandledRejection`


Made with [Cursor](https://cursor.com)