### PR TITLE
fix: prevent UNSAFE_TRANSACTION under concurrent sql.begin()

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -170,11 +170,15 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         : (query = q, query.active = true)
 
       build(q)
-      return write(toBuffer(q))
+      const written = write(toBuffer(q))
+      if (written && q.options.onexecute) {
+        q.options.onexecute(connection)
+        return false
+      }
+      return written
         && !q.describeFirst
         && !q.cursorFn
         && sent.length < max_pipeline
-        && (!q.options.onexecute || q.options.onexecute(connection))
     } catch (error) {
       sent.length === 0 && write(Sync)
       errored(error)
@@ -295,7 +299,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
   /* c8 ignore next 3 */
   function drain() {
-    !query && onopen(connection)
+    !query && !connection.reserved && onopen(connection)
   }
 
   function data(x) {

--- a/src/index.js
+++ b/src/index.js
@@ -336,6 +336,11 @@ function Postgres(a, b) {
     if (closed.length)
       return connect(closed.shift(), query)
 
+    if (query.options.onexecute) {
+      queries.push(query)
+      return
+    }
+
     busy.length
       ? go(busy.shift(), query)
       : queries.push(query)

--- a/tests/race-condition.js
+++ b/tests/race-condition.js
@@ -1,0 +1,101 @@
+// Reproduces UNSAFE_TRANSACTION under concurrent sql.begin().
+// See https://github.com/porsager/postgres/issues/823
+
+import postgres from "../src/index.js";
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const pgOptions = {
+  db: "postgres_js_test",
+  user: "postgres_js_test",
+  idle_timeout: null,
+  connect_timeout: 10,
+};
+
+async function canConnect() {
+  return new Promise((resolve) => {
+    const sql = postgres({ ...pgOptions, max: 1 });
+    sql`SELECT 1`
+      .then(() => sql.end().then(() => resolve(true)))
+      .catch(() => {
+        sql.end({ timeout: 0 }).catch(() => {});
+        resolve(false);
+      });
+  });
+}
+
+const ITERATIONS = 20;
+
+async function runOnce() {
+  const errors = [];
+  const sql = postgres({ ...pgOptions, max: 3, max_pipeline: 2 });
+
+  try {
+    await sql`SELECT 1`;
+
+    const blockers = Array.from({ length: 3 }, () =>
+      sql`SELECT pg_sleep(0.5)`.catch((e) => { errors.push(e); return e; }),
+    );
+    await delay(10);
+
+    const queries = Array.from({ length: 6 }, (_, i) =>
+      sql`SELECT ${i}::int`.catch((e) => { errors.push(e); return e; }),
+    );
+    const begins = Array.from({ length: 5 }, (_, i) =>
+      sql.begin(async (tx) => {
+        await tx`SELECT ${i}::int as n`;
+        return "ok";
+      }).catch((e) => { errors.push(e); return e; }),
+    );
+
+    await Promise.allSettled([
+      ...blockers,
+      ...queries.map((p) => Promise.race([p, delay(10000).then(() => { throw new Error("timeout"); })])),
+      ...begins.map((p) => Promise.race([p, delay(10000).then(() => { throw new Error("timeout"); })])),
+    ]);
+  } finally {
+    await sql.end({ timeout: 2 }).catch(() => {});
+  }
+
+  return errors.filter((e) => e.code === "UNSAFE_TRANSACTION").length;
+}
+
+async function run() {
+  console.log("\n  Race Condition Test");
+  console.log(`  Running scenario ${ITERATIONS} times to expose the race\n`);
+
+  const dbAvailable = await canConnect();
+  if (!dbAvailable) {
+    console.log("  SKIP: PostgreSQL not available (need postgres_js_test db/user)");
+    console.log("  Set up with: createuser postgres_js_test && createdb -O postgres_js_test postgres_js_test\n");
+    process.exit(1);
+  }
+
+  let totalUnsafe = 0;
+  let iterationsWithErrors = 0;
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const count = await runOnce();
+    if (count > 0) {
+      iterationsWithErrors++;
+      totalUnsafe += count;
+      process.stdout.write("\x1b[31mF\x1b[0m");
+    } else {
+      process.stdout.write("\x1b[32m.\x1b[0m");
+    }
+  }
+  console.log("");
+
+  if (totalUnsafe > 0) {
+    console.log(`\n  \x1b[31mFAIL\x1b[0m ${totalUnsafe} UNSAFE_TRANSACTION error(s) across ${iterationsWithErrors}/${ITERATIONS} iterations\n`);
+    process.exit(1);
+  } else {
+    console.log(`\n  \x1b[32mPASS\x1b[0m No UNSAFE_TRANSACTION errors across ${ITERATIONS} iterations\n`);
+    process.exit(0);
+  }
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Fixes the `UNSAFE_TRANSACTION` race reported in porsager/postgres#823 (likely related to porsager/postgres#827).

## Root cause

When you call `sql.begin()`, the driver:
1. Picks a connection from the pool
2. Marks it **reserved** — "this connection belongs to this transaction, don't give it to anyone else"
3. Sends `BEGIN` to PostgreSQL
4. Runs your queries
5. Sends `COMMIT` and un-reserves the connection

Under concurrent load, the "reserved" mark can be lost or overwritten before step 4 finishes. Another `sql.begin()` grabs the same connection and sends its own `BEGIN`. PostgreSQL sees a second `BEGIN` while already in a transaction, warns `25001` "there is already a transaction in progress", and the driver throws `UNSAFE_TRANSACTION`.

Three code paths in `src/connection.js` and `src/index.js` can produce this:

1. **`execute()` short-circuit** — `onexecute` (which sets `connection.reserved`) is at the tail of an `&&` chain. When `sent.length >= max_pipeline` (or `write()` returns false), the chain short-circuits and `onexecute` is skipped, so the connection is never marked reserved.
2. **`handler()` pipelining** — a queued `BEGIN` can be dispatched onto a busy connection that already holds another transaction.
3. **`drain()` on reserved connection** — the socket drain callback can call `onopen()` on a connection that is currently reserved, returning it to the pool mid-transaction.

## Fix

Three small, focused changes:

| Where | What it does |
|---|---|
| `src/connection.js` `execute()` | Fire `onexecute` unconditionally when `write()` succeeds, and return `false` so the connection is marked full (no further pipelining onto it). |
| `src/connection.js` `drain()` | Don't call `onopen()` on a reserved connection. |
| `src/index.js` `handler()` | Never dispatch an `onexecute` query (BEGIN) onto a busy connection — always queue it. |

## Reproduction

`tests/race-condition.js` reproduces the bug **against unmodified PostgreSQL on localhost**. It runs the scenario 20 times: pool `max: 3, max_pipeline: 2`, hold all 3 connections busy with `pg_sleep`, then fire 6 regular queries + 5 `sql.begin()` concurrently.

- **On unfixed master**: 12–16 / 20 iterations fail, PostgreSQL reports `25001` "there is already a transaction in progress"
- **On this fix**: 20 / 20 iterations pass

Setup:

```
createuser postgres_js_test
createdb -O postgres_js_test postgres_js_test
node tests/race-condition.js
```
