### PR TITLE
Run onexecute regardless of max_pipeline so begin() works at 0

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -170,11 +170,12 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         : (query = q, query.active = true)
 
       build(q)
-      return write(toBuffer(q))
+      const written = write(toBuffer(q))
+      written && q.options.onexecute && q.options.onexecute(connection)
+      return written
         && !q.describeFirst
         && !q.cursorFn
         && sent.length < max_pipeline
-        && (!q.options.onexecute || q.options.onexecute(connection))
     } catch (error) {
       sent.length === 0 && write(Sync)
       errored(error)

--- a/tests/index.js
+++ b/tests/index.js
@@ -332,6 +332,27 @@ t('Helpers in Transaction', async() => {
   ))[0].x]
 })
 
+t('Transaction works with max_pipeline 0', async() => {
+  const sql = postgres({ ...options, max: 4, max_pipeline: 0 })
+  return [1, (await sql.begin(sql => sql`select 1 as x`))[0].x, await sql.end()]
+})
+
+t('Transaction with sequential queries works with max_pipeline 0', async() => {
+  const sql = postgres({ ...options, max: 4, max_pipeline: 0 })
+  return ['testing', await sql.begin(async sql => {
+    await sql`select set_config('postgres_js.test', 'testing', true)`
+    return (await sql`select current_setting('postgres_js.test') as x`)[0].x
+  }), await sql.end()]
+})
+
+t('Transaction with concurrent queries works with max_pipeline 0', async() => {
+  const sql = postgres({ ...options, max: 4, max_pipeline: 0 })
+  return ['testing', (await sql.begin(sql => [
+    sql`select set_config('postgres_js.test', 'testing', true)`,
+    sql`select current_setting('postgres_js.test') as x`
+  ]))[1][0].x, await sql.end()]
+})
+
 t('Undefined values throws', async() => {
   let error
 


### PR DESCRIPTION
Fixes #1210

### Cause

`execute(q)` in `src/connection.js` returns one `&&` chain that does two unrelated jobs: it decides whether the pool may pipeline another query onto this connection, **and** it runs the query's `onexecute` hook as its last term:

```js
      return write(toBuffer(q))
        && !q.describeFirst
        && !q.cursorFn
        && sent.length < max_pipeline
        && (!q.options.onexecute || q.options.onexecute(connection))
```

`begin()` sends `BEGIN` with `{ onexecute }` and relies on that hook to capture the connection, `move(c, reserved)` and set `c.reserved`. With `max_pipeline: 0` the `sent.length < max_pipeline` term is always false, so the chain short-circuits before the hook. The connection is never reserved, and the `UNSAFE_TRANSACTION` guard in `CommandComplete` rejects every transaction.

### Change

Run the hook whenever the query was actually written, independent of pipeline capacity, and keep the return value's meaning ("may the pool pipeline more onto this connection") unchanged:

```js
      const written = write(toBuffer(q))
      written && q.options.onexecute && q.options.onexecute(connection)
      return written
        && !q.describeFirst
        && !q.cursorFn
        && sent.length < max_pipeline
```

**`max_pipeline > 0`: behaviour is identical.** `onexecute` in `begin()` (the only caller) returns a truthy value (the assigned `c.reserved` function), so the old chain was truthy exactly when the new one is, and the hook ran in exactly the cases it runs now (previously it also only ran when `write()` returned truthy, which `written &&` preserves).

**`max_pipeline: 0`:** `execute()` reserves the connection and returns `false`, so `go()` moves it to `full`. `c.reserved` is set, so the BEGIN passes the guard. On the BEGIN's ReadyForQuery (status `T`), `connection.reserved()` runs, finds the transaction's queue empty and moves the connection back to `reserved`. The transaction callback only starts after that (it is awaited behind the BEGIN), and each statement it issues goes through `begin()`'s `handler`: `execute()` returns `false` -> `move(c, full)`; anything issued while in `full` is pushed onto the transaction's own `queries` and drained one at a time by `c.reserved()` on each ReadyForQuery. Ordering is preserved and nothing is pipelined onto the socket, which is the point of the setting.

### Tests

Three tests added to `tests/index.js`, each on a client with `{ max: 4, max_pipeline: 0 }`:

- a single-statement `sql.begin(sql => sql\`select 1 as x\`)` returns `1`
- two sequential statements in one transaction (`set_config(..., true)` then `current_setting`, so it also proves they ran on the same transaction)
- two concurrent statements in one transaction (array form), which exercises the `queries` queue path

Run in isolation against a plain PostgreSQL 16 through the repo's `tests/test.js` harness: all three pass with this change; without it the first fails with `UNSAFE_TRANSACTION`. `eslint src tests` with the repo config is clean.

**The full suite did not run here**: `tests/bootstrap.js` needs `psql`/`createdb`/`dropdb` on PATH and a server it may reconfigure (`ssl=on`, `wal_level=logical`, prepared transactions), which this environment does not have. CI should cover it.

I left `cjs/`, `deno/` and `cf/` untouched, following the pattern of separate `build` commits in this repo; happy to regenerate them in this PR if preferred.
