### PR TITLE
Reject transaction work after its connection closes

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -438,6 +438,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     remaining = 0
     incomings = null
     clearImmediate(nextWriteTimer)
+    chunk = nextWriteTimer = null
     socket.removeListener('data', data)
     socket.removeListener('connect', connected)
     idleTimer.cancel()
@@ -451,6 +452,9 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
       return reconnect()
 
     !hadError && (query || sent.length) && error(Errors.connection('CONNECTION_CLOSED', options, socket))
+    query = results = errorResponse = null
+    result = new Result()
+    rows = 0
     closedTime = performance.now()
     hadError && options.shared.retries++
     delay = (typeof backoff === 'function' ? backoff(options.shared.retries) : backoff) * 1000

--- a/src/index.js
+++ b/src/index.js
@@ -236,13 +236,19 @@ function Postgres(a, b) {
     const queries = Queue()
     let savepoints = 0
       , connection
+      , closedError
       , prepare = null
 
     try {
       await sql.unsafe('begin ' + options.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
       return await Promise.race([
         scope(connection, fn),
-        new Promise((_, reject) => connection.onclose = reject)
+        new Promise((_, reject) => connection.onclose = error => {
+          closedError = error
+          while (queries.length)
+            queries.shift().reject(error)
+          reject(error)
+        })
       ])
     } catch (error) {
       throw error
@@ -290,6 +296,8 @@ function Postgres(a, b) {
 
       function handler(q) {
         q.catch(e => uncaughtError || (uncaughtError = e))
+        if (closedError)
+          return q.reject(closedError)
         c.queue === full
           ? queries.push(q)
           : c.execute(q) || move(c, full)

--- a/tests/index.js
+++ b/tests/index.js
@@ -2501,6 +2501,81 @@ t('Ensure transactions throw if connection is closed dwhile there is no query', 
   return ['CONNECTION_CLOSED', x.code]
 })
 
+t('Disconnect rejects queued transaction queries and allows reconnect', async() => {
+  const sql = postgres({ ...options, max_pipeline: 1, fetch_types: false })
+  let queries
+
+  try {
+    const error = await sql.begin(sql => {
+      queries = [
+        sql`select pg_terminate_backend(pg_backend_pid())`.execute(),
+        sql`select 1`.execute(),
+        sql`select 2`.execute()
+      ]
+      return Promise.allSettled(queries)
+    }).catch(x => x)
+
+    const results = await Promise.allSettled(queries)
+    const [{ x }] = await sql`select 1 as x`
+    return [
+      'CONNECTION_CLOSED,rejected,rejected,rejected,1',
+      [error.code, ...results.map(x => x.status), x].join(',')
+    ]
+  } finally {
+    await sql.end({ timeout: 0 })
+  }
+})
+
+t('Disconnected transaction cannot query a reused connection', async() =>
+  withDisconnectedTransaction(({ sql, disconnected }) => sql.begin(async sql => {
+    await sql`select set_config('postgres_js.test', 'replacement', true)`
+    const result = await disconnected`select current_setting('postgres_js.test') as x`.catch(x => x)
+    return ['CONNECTION_CLOSED', result.code]
+  }))
+)
+
+t('Disconnected transaction cannot commit a reused connection', async() =>
+  finishDisconnectedTransaction()
+)
+
+t('Disconnected transaction cannot roll back a reused connection', async() =>
+  finishDisconnectedTransaction(new Error('original callback failed'))
+)
+
+function finishDisconnectedTransaction(error) {
+  return withDisconnectedTransaction(({ sql, finish }) => sql.begin(async sql => {
+    const [{ x: before }] = await sql`select txid_current()::text as x`
+    finish(error)
+    await new Promise(resolve => setImmediate(resolve))
+    const [{ x: after }] = await sql`select txid_current()::text as x`
+    return [before, after]
+  }))
+}
+
+async function withDisconnectedTransaction(fn) {
+  const pool = postgres({ ...options, fetch_types: false })
+  let finish
+    , ready
+  const gate = new Promise((resolve, reject) => finish = error => error ? reject(error) : resolve())
+  const connected = new Promise(resolve => ready = resolve)
+  const failed = pool.begin(async sql => {
+    const [{ pid }] = await sql`select pg_backend_pid() as pid`
+    ready({ disconnected: sql, pid })
+    await gate
+  }).catch(x => x)
+
+  try {
+    const { disconnected, pid } = await Promise.race([connected, failed.then(error => { throw error })])
+    await sql`select pg_terminate_backend(${ pid }::int)`
+    await failed
+    return await fn({ sql: pool, disconnected, finish })
+  } finally {
+    finish()
+    await new Promise(resolve => setImmediate(resolve))
+    await pool.end({ timeout: 0 })
+  }
+}
+
 t('Custom socket', {}, async() => {
   let result
   const sql = postgres({


### PR DESCRIPTION
Fixes #1216.

If a backend disconnects while a `sql.begin()` callback is awaiting other work, `begin()` rejects but the callback keeps running. Once the pool reconnects, that callback can issue queries on the replacement connection. Returning or throwing from it can also commit or roll back a different transaction. Queries still queued inside the original transaction can remain pending indefinitely.

Keep the close error on the transaction, reject its queued queries, and reject subsequent queries through that transaction's handler, including automatic commit/rollback. Clear the connection's pending write and query/result/error state before reuse, too. Without that reset, the first query after reconnect can receive the old backend's fatal error.

The four regression tests cover queued queries, a query through the disconnected transaction, and late commit/rollback. The latter three share a fixture that pauses the original callback until a replacement transaction is open. No new dependencies or public API changes.

Related to #1204. This reproduction specifically covers a backend disconnect followed by connection reuse; I haven't verified that it explains the original report.

### Reproduce

Save the following as `repro.mjs` in the repository root. It needs Node 22 and a PostgreSQL login that can terminate its own other sessions.

```js
import assert from 'node:assert/strict'
import postgres from './src/index.js'

const pool = postgres({ max: 1 })
const admin = postgres({ max: 1 })
let resume
  , connected
const gate = new Promise(resolve => { resume = resolve })
const ready = new Promise(resolve => { connected = resolve })
const failed = pool.begin(async sql => {
  connected((await sql`select 1`).state.pid)
  await gate
}).catch(error => error)

try {
  await admin`select pg_terminate_backend(${ await ready }::int)`
  assert.equal((await failed).code, 'CONNECTION_CLOSED')
  await pool.begin(async sql => {
    const [{ id: before }] = await sql`select txid_current()::text as id`
    resume()
    await new Promise(resolve => setImmediate(resolve))
    const [{ id: after }] = await sql`select txid_current()::text as id`
    console.log({ before, after })
    assert.equal(after, before)
  })
} finally {
  resume()
  await Promise.all([pool.end({ timeout: 0 }), admin.end({ timeout: 0 })])
}
```

For a disposable local server:

```sh
docker run --rm -d --name postgres-disconnect-repro \
  -p 127.0.0.1:55432:5432 \
  -e POSTGRES_HOST_AUTH_METHOD=trust postgres:17
docker exec postgres-disconnect-repro pg_isready -U postgres
PGHOST=127.0.0.1 PGPORT=55432 PGUSER=postgres PGDATABASE=postgres node repro.mjs
docker stop postgres-disconnect-repro
```

Wait for `pg_isready` to report that the server is accepting connections before running the script. On upstream `411429e`, the assertion fails because the transaction IDs differ: the old callback has committed the replacement transaction. On this branch they stay equal and the script exits successfully. I verified both outcomes.

### Tests

The first commit, `0282301`, adds only the regression tests; the second applies the fix. With the PostgreSQL setup from [the existing test workflow](https://github.com/porsager/postgres/blob/411429e7bd7a3d61155ca9a70a97c111823702ea/.github/workflows/test.yml) in place:

```sh
git worktree add ../postgres-disconnect-before 0282301
(cd ../postgres-disconnect-before && PGUSER=postgres PGSOCKET=/var/run/postgresql npm run test:esm)
PGUSER=postgres PGSOCKET=/var/run/postgresql npm test
npm exec --yes --package=eslint@8.57.1 -- eslint src tests
```

The first run times out in `Disconnect rejects queued transaction queries and allows reconnect`. The fixed branch passes. The full suite needs both PostgreSQL servers from the workflow (ports 5432 and 5433), SSL, logical replication, prepared transactions, the PostgreSQL CLI tools, and Deno 1.x. Use disposable databases: the existing bootstrap changes server settings and recreates its test database and roles.

Validated against PostgreSQL 17.11:

- Node 12.22.12 and 22.22.0: all 268 tests pass in both ESM and CommonJS.
- Deno 1.46.3: all 268 tests pass.
- Bun 1.4.2: the standalone reproduction and focused probes for all four failure cases pass. The full suite cannot register tests because `tests/test.js:20` assumes a Node stack format; the same failure occurs on unmodified upstream.
- ESLint passes.
